### PR TITLE
added api routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,14 @@
 Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'auth'
+  namespace :v1 do
+    resources :competitions, only: [] do
+      resources :matches, only: [:index]
+      resources :leagues, only: [:index, :create, :destroy]
+      resources :users, only: [:show]
+      resources :memberships, only: [:create, :destroy]
+    end
+    resources :matches, only: [] do
+      resources :predictions, only: [:create, :update]
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,12 +3,15 @@ Rails.application.routes.draw do
   namespace :v1 do
     resources :competitions, only: [] do
       resources :matches, only: [:index]
-      resources :leagues, only: [:index, :create, :destroy]
+      resources :leagues, only: [:index, :create]
       resources :users, only: [:show]
-      resources :memberships, only: [:create, :destroy]
+      resources :memberships, only: [:create]
     end
     resources :matches, only: [] do
-      resources :predictions, only: [:create, :update]
+      resources :predictions, only: [:create]
     end
+    resources :predictions, only: [:update]
+    resources :leagues, only: [:destroy]
+    resources :memberships, only: [:destroy]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,15 +4,12 @@ Rails.application.routes.draw do
     resources :competitions, only: [:show] do
       resources :leagues, only: [:index, :create]
     end
-    resources :matches, only: [] do
-      resources :predictions, only: [:create]
+    resources :matches, only: [:index], shallow: true do
+      resources :predictions, only: [:create, :update]
     end
-    resources :leagues, only: [:destroy] do
-      resources :memberships, only: [:create]
+    resources :leagues, only: [:destroy], shallow: true do
+      resources :memberships, only: [:create, :destroy]
     end
-    resources :matches, only: [:index]
-    resources :predictions, only: [:update]
-    resources :memberships, only: [:destroy]
     resources :users, only: [:show]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,6 @@
 Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'auth'
   namespace :v1 do
-    resources :users, only: [:show] do
-      resources :matches, only: [:index]
-    end
     resources :competitions, only: [:show] do
       resources :leagues, only: [:index, :create]
     end
@@ -13,7 +10,9 @@ Rails.application.routes.draw do
     resources :leagues, only: [:destroy] do
       resources :memberships, only: [:create]
     end
+    resources :matches, only: [:index]
     resources :predictions, only: [:update]
     resources :memberships, only: [:destroy]
+    resources :users, only: [:show]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,17 +1,19 @@
 Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'auth'
   namespace :v1 do
-    resources :competitions, only: [] do
+    resources :users, only: [:show] do
       resources :matches, only: [:index]
+    end
+    resources :competitions, only: [:show] do
       resources :leagues, only: [:index, :create]
-      resources :users, only: [:show]
-      resources :memberships, only: [:create]
     end
     resources :matches, only: [] do
       resources :predictions, only: [:create]
     end
+    resources :leagues, only: [:destroy] do
+      resources :memberships, only: [:create]
+    end
     resources :predictions, only: [:update]
-    resources :leagues, only: [:destroy]
     resources :memberships, only: [:destroy]
   end
 end


### PR DESCRIPTION
So actually I'm unsure the main page of the app- the page where the user sees all of the matches and their predictions (if any).
 
My first instinct was to just have it at `/matches` because if a user is logged in, easy to get the predictions for the matches, right? 
But then, if you want to see other people's predictions (maybe after they're locked) then the routes definitely **could not** be `/matches` for them. Unless you passed user_id in the params or something.
So i'm thinking that it could be at `users/:id` since that's basically all you need to see about a user anyway. or you could have `predictions/users/:id`, but then it seems odd to have two separate routes basically handling the same thing, right?

But also, we need to scope this in terms of the competition right? we can't just do `/matches` since we plan to add more competitions later on.

To summarize:
- I nested routes inside of `/competitions/:id` (except for ones that don't need nesting) 
- i left `competitions/:id/matches` in there but I feel like we should use the same route for both the logged in user + other users.
- something doesn't feel right with `/competitions/:id/users/:id`, i feel like there's a better way to do it

#11 