### PR TITLE
trackable was enabled but not added to the users table

### DIFF
--- a/db/migrate/20210409090454_add_trackable_fields_to_user.rb
+++ b/db/migrate/20210409090454_add_trackable_fields_to_user.rb
@@ -1,0 +1,11 @@
+class AddTrackableFieldsToUser < ActiveRecord::Migration[6.1]
+  def change
+    change_table :users do |t|
+      t.integer  :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.inet     :current_sign_in_ip
+      t.inet     :last_sign_in_ip
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_07_082013) do
+ActiveRecord::Schema.define(version: 2021_04_09_090454) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -152,6 +152,11 @@ ActiveRecord::Schema.define(version: 2021_04_07_082013) do
     t.json "tokens"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.inet "current_sign_in_ip"
+    t.inet "last_sign_in_ip"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
trackable was enabled but not added to the users table

the whole Devise creation vs devise-token-auth creation doesn't seem to be very consistent.  