### PR TITLE
Feature: Point calculations

### DIFF
--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -2,26 +2,4 @@ class Affiliation < ApplicationRecord
   belongs_to :team
   belongs_to :group
   validates_uniqueness_of :team, scope: :group
-
-  def points
-    victories.count * 3 + draws.count
-  end
-
-  def goal_diff
-    victories.sum('ABS(team_home_score - team_away_score)') - defeats.sum('ABS(team_home_score - team_away_score)')
-  end
-
-  private
-
-  def victories
-    team.victories.where(group: group)
-  end
-
-  def defeats
-    team.defeats.where(group: group)
-  end
-
-  def draws
-    team.draws.where(group: group)
-  end
 end

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -2,4 +2,13 @@ class Affiliation < ApplicationRecord
   belongs_to :team
   belongs_to :group
   validates_uniqueness_of :team, scope: :group
+
+  def points
+    # Could probably be optimized into a single query
+    team.victories.count * 3 + team.draws.count
+  end
+
+  def goal_diff
+    # TODO
+  end
 end

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -4,11 +4,24 @@ class Affiliation < ApplicationRecord
   validates_uniqueness_of :team, scope: :group
 
   def points
-    # Could probably be optimized into a single query
-    team.victories.count * 3 + team.draws.count
+    victories.count * 3 + draws.count
   end
 
   def goal_diff
-    # TODO
+    victories.sum('ABS(team_home_score - team_away_score)') - defeats.sum('ABS(team_home_score - team_away_score)')
+  end
+
+  private
+
+  def victories
+    team.victories.where(group: group)
+  end
+
+  def defeats
+    team.defeats.where(group: group)
+  end
+
+  def draws
+    team.draws.where(group: group)
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,11 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def self.execute_sql(query, args = {})
+    query = sanitize_sql([query, args])
+    results = ActiveRecord::Base.connection.execute(query)
+    return unless results.present?
+
+    results
+  end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -23,19 +23,27 @@ class Group < ApplicationRecord
       CASE -- Calculating goal difference
         WHEN team_home_id = teams.id THEN team_home_score - team_away_score
         ELSE team_away_score - team_home_score
-      END AS goal_diff
+      END AS match_goal_diff
       FROM teams
       JOIN matches ON team_home_id = teams.id OR team_away_id = teams.id
       WHERE status = 'finished' AND group_id = :group_id
     )
-    SELECT teams.*, SUM(result) AS points, SUM(goal_diff) AS total_goal_diff, COUNT(*) AS matches_count
+    SELECT teams.*, SUM(result) AS points, SUM(match_goal_diff) AS goal_diff, COUNT(*) AS matches_count
     FROM match_results
     JOIN teams ON team_id = teams.id
     GROUP BY teams.id
-    ORDER BY points DESC, total_goal_diff DESC
+    ORDER BY points DESC, goal_diff DESC
   SQL
 
   def ranking
     Group.execute_sql(RANKING_SQL, group_id: id)
+  end
+
+  def leader
+    Team.find(ranking.first['id'])
+  end
+
+  def runner_up
+    Team.find(ranking[1]['id'])
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -5,4 +5,37 @@ class Group < ApplicationRecord
   has_many :teams, through: :affiliations
   validates :name, presence: true
   validates_uniqueness_of :name, scope: :round
+
+  RANKING_SQL = <<-SQL.freeze
+    WITH match_results AS (
+      SELECT teams.id AS team_id, matches.id AS match_id,
+      CASE -- Calculating points earned per match
+        WHEN
+          (team_home_id = teams.id AND team_home_score > team_away_score)
+          OR (team_away_id = teams.id AND team_home_score < team_away_score)
+        THEN 3
+        WHEN
+          (team_home_id = teams.id AND team_home_score < team_away_score) OR
+          (team_away_id = teams.id AND team_home_score > team_away_score)
+        THEN 0
+        ELSE 1
+      END AS result,
+      CASE -- Calculating goal difference
+        WHEN team_home_id = teams.id THEN team_home_score - team_away_score
+        ELSE team_away_score - team_home_score
+      END AS goal_diff
+      FROM teams
+      JOIN matches ON team_home_id = teams.id OR team_away_id = teams.id
+      WHERE status = 'finished' AND group_id = :group_id
+    )
+    SELECT teams.*, SUM(result) AS points, SUM(goal_diff) AS total_goal_diff, COUNT(*) AS matches_count
+    FROM match_results
+    JOIN teams ON team_id = teams.id
+    GROUP BY teams.id
+    ORDER BY points DESC, total_goal_diff DESC
+  SQL
+
+  def ranking
+    Group.execute_sql(RANKING_SQL, group_id: id)
+  end
 end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -8,9 +8,9 @@ class Match < ApplicationRecord
   has_many :users, through: :predictions
   validates :kickoff_time, presence: true
   validates :status, presence: true
-  enum status: %i[upcoming started finished]
-  validates_uniqueness_of :kickoff_time, scope: [:team_home, :team_away]
+  validates_uniqueness_of :kickoff_time, scope: %i[team_home team_away]
   validate :round_xor_group
+  enum status: { upcoming: 'upcoming', started: 'started', finished: 'finished' }, _default: :upcoming
 
   def draw?
     return unless finished?

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -10,6 +10,7 @@ class Team < ApplicationRecord
     Match.where('team_home_id = :id OR team_away_id = :id', id: id)
   end
 
+  # These methods are not used for Group rankings, but could be used for individual team stats
   def victories
     matches.finished.where(<<-SQL, id: id)
       (team_home_id = :id AND team_home_score > team_away_score) OR

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -9,4 +9,25 @@ class Team < ApplicationRecord
     # teams can either be home or away
     Match.where('team_home_id = :id OR team_away_id = :id', id: id)
   end
+
+  def victories
+    matches.finished.where(<<-SQL, id: id)
+      (team_home_id = :id AND team_home_score > team_away_score) OR
+      (team_away_id = :id AND team_home_score < team_away_score)
+    SQL
+  end
+
+  def defeats
+    matches.finished.where(<<-SQL, id: id)
+      (team_home_id = :id AND team_home_score < team_away_score) OR
+      (team_away_id = :id AND team_home_score > team_away_score)
+    SQL
+  end
+
+  def draws
+    matches.finished.where(<<-SQL, id: id)
+      (team_home_id = :id OR team_away_id = :id) AND
+      team_home_score = team_away_score
+    SQL
+  end
 end

--- a/db/migrate/20210416124931_change_status_to_string.rb
+++ b/db/migrate/20210416124931_change_status_to_string.rb
@@ -1,0 +1,9 @@
+class ChangeStatusToString < ActiveRecord::Migration[6.1]
+  def up
+    change_column :matches, :status, :string, default: nil
+  end
+
+  def down
+    change_column :matches, :status, :integer, using: 'status::integer', default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_15_013709) do
+ActiveRecord::Schema.define(version: 2021_04_16_124931) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,7 +85,7 @@ ActiveRecord::Schema.define(version: 2021_04_15_013709) do
     t.datetime "kickoff_time"
     t.integer "team_home_score"
     t.integer "team_away_score"
-    t.integer "status", default: 0
+    t.string "status"
     t.bigint "group_id"
     t.bigint "team_away_id"
     t.bigint "team_home_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -100,12 +100,9 @@ end
 ScrapeMatchesService.new.call
 
 puts 'Assigning random scores to matches before June 22nd'
-Match.all.each do |match|
-  if match.kickoff_time < Date.new(2021, 06, 22)
-    match.update(team_away_score: rand(4), team_home_score: rand(4), status: :finished)
-  else
-    # Needed when migrating status enum from integer to string
-    match.update(status: :upcoming)
-  end
+Match.where('kickoff_time < ?', Date.new(2021, 6, 22)).each do |match|
+  match.update(team_away_score: rand(4), team_home_score: rand(4), status: :finished)
 end
+# Needed when migrating status enum from integer to string:
+Match.where('kickoff_time >= ?', Date.new(2021, 6, 22)).update(status: :upcoming)
 puts "...#{Match.finished.count} Finished Matches and #{Match.upcoming.count} Upcoming Matches"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -98,3 +98,14 @@ puts 'Adding Trouni and Doug to the league'
 end
 
 ScrapeMatchesService.new.call
+
+puts 'Assigning random scores to matches before June 22nd'
+Match.all.each do |match|
+  if match.kickoff_time < Date.new(2021, 06, 22)
+    match.update(team_away_score: rand(4), team_home_score: rand(4), status: :finished)
+  else
+    # Needed when migrating status enum from integer to string
+    match.update(status: :upcoming)
+  end
+end
+puts "...#{Match.finished.count} Finished Matches and #{Match.upcoming.count} Upcoming Matches"


### PR DESCRIPTION
Resolves #16 

Main changes that have been implemented:
- [x] Changed the `status` enum from an integer to a string, so that the SQL queries are more explicit (_i.e._ `WHERE status = 'finished'` instead of `WHERE status = 2`)
- [x] Implemented a `Group#ranking` SQL query and method to calculate the `points`, `goal_diff` and rank all teams by points > goal_diff.
- [x] Seeds: Added random scores to be able to test the `Group#ranking` method.

The `#ranking` method can be tested in the console using:
```rb
Group.first.ranking.as_json

# returns for example
{"id"=>3, "name"=>"Turkey", "abbrev"=>"TUR", "created_at"=>"2021-04-09T08:18:13.926Z", "updated_at"=>"2021-04-09T08:18:30.020Z", "points"=>9, "goal_diff"=>5, "matches_count"=>3}
{"id"=>1, "name"=>"Italy", "abbrev"=>"ITA", "created_at"=>"2021-04-09T08:18:13.854Z", "updated_at"=>"2021-04-09T08:18:17.214Z", "points"=>4, "goal_diff"=>0, "matches_count"=>3}
{"id"=>2, "name"=>"Switzerland", "abbrev"=>"SUI", "created_at"=>"2021-04-09T08:18:13.910Z", "updated_at"=>"2021-04-09T08:18:24.262Z", "points"=>2, "goal_diff"=>-2, "matches_count"=>3}
{"id"=>4, "name"=>"Wales", "abbrev"=>"WAL", "created_at"=>"2021-04-09T08:18:13.946Z", "updated_at"=>"2021-04-09T08:18:38.406Z", "points"=>1, "goal_diff"=>-3, "matches_count"=>3}
```