### PR TITLE
Prediction match controllers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'pg', '~> 1.1'
 # Use Puma as the app server
 gem 'puma', '~> 5.0'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-# gem 'jbuilder', '~> 2.7'
+gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,8 @@ GEM
       domain_name (~> 0.5)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    jbuilder (2.11.2)
+      activesupport (>= 5.0.0)
     json (2.5.1)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -269,6 +271,7 @@ DEPENDENCIES
   devise_token_auth!
   dotenv-rails
   faker
+  jbuilder (~> 2.7)
   listen (~> 3.3)
   mailcatcher
   omniauth

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,6 @@ class ApplicationController < ActionController::API
 
   before_action :authenticate_user!, unless: :token_auth_controller?
 
-  # Pundit: white-list approach.
   after_action :verify_authorized, except: :index, unless: :skip_pundit?
   after_action :verify_policy_scoped, only: :index, unless: :skip_pundit?
 

--- a/app/controllers/v1/matches_controller.rb
+++ b/app/controllers/v1/matches_controller.rb
@@ -6,9 +6,9 @@ class V1::MatchesController < ApplicationController
     @competition = Competition.find_by(id: params[:competition_id])
     @matches =
       if @competition
-        policy_scope(Match).where(group: @competition.groups)
+        policy_scope(Match).where(group: @competition.groups).order(:kickoff_time)
       else
-        policy_scope([:user, Match])
+        policy_scope([:user, Match]).order(:kickoff_time)
       end
   end
 end

--- a/app/controllers/v1/matches_controller.rb
+++ b/app/controllers/v1/matches_controller.rb
@@ -8,7 +8,7 @@ class V1::MatchesController < ApplicationController
       if @competition
         policy_scope(Match).where(group: @competition.groups)
       else
-        policy_scope(Match)
+        policy_scope([:user, Match])
       end
   end
 end

--- a/app/controllers/v1/matches_controller.rb
+++ b/app/controllers/v1/matches_controller.rb
@@ -3,7 +3,12 @@ class V1::MatchesController < ApplicationController
   # /matches?competition_id=:id&user_id=:id
   def index
     @user = User.find_by(id: params[:user_id]) || current_user
-    # @competition = Competition.find_by(id: params[:competition_id])
-    @matches = policy_scope(Match)
+    @competition = Competition.find_by(id: params[:competition_id])
+    @matches =
+      if @competition
+        policy_scope(Match).where(group: @competition.groups)
+      else
+        policy_scope(Match)
+      end
   end
 end

--- a/app/controllers/v1/matches_controller.rb
+++ b/app/controllers/v1/matches_controller.rb
@@ -1,0 +1,2 @@
+class V1::MatchesController < ApplicationController
+end

--- a/app/controllers/v1/matches_controller.rb
+++ b/app/controllers/v1/matches_controller.rb
@@ -1,2 +1,9 @@
 class V1::MatchesController < ApplicationController
+
+  # /matches?competition_id=:id&user_id=:id
+  def index
+    @user = User.find_by(id: params[:user_id]) || current_user
+    # @competition = Competition.find_by(id: params[:competition_id])
+    @matches = policy_scope(Match)
+  end
 end

--- a/app/controllers/v1/predictions_controller.rb
+++ b/app/controllers/v1/predictions_controller.rb
@@ -5,6 +5,7 @@ class V1::PredictionsController < ApplicationController
     @predition = Predicition.new(prediction_params)
     @prediction.match = @match
     @prediction.user = current_user
+    authorize @prediction
     if @prediction.save
       render :show, status: :created
     else
@@ -14,6 +15,7 @@ class V1::PredictionsController < ApplicationController
 
   def update
     @predition = Predicition.find_by(user: current_user, match: params[:match_id])
+    authorize @prediction
     if @prediction.update(prediction_params)
       render :show
     else

--- a/app/controllers/v1/predictions_controller.rb
+++ b/app/controllers/v1/predictions_controller.rb
@@ -1,0 +1,34 @@
+class V1::PredictionsController < ApplicationController
+
+  def create
+    @match = Match.find(params[:match_id])
+    @predition = Predicition.new(prediction_params)
+    @prediction.match = @match
+    @prediction.user = current_user
+    if @prediction.save
+      render :show, status: :created
+    else
+      render_error
+    end
+  end
+
+  def update
+    @predition = Predicition.find_by(user: current_user, match: params[:match_id])
+    if @prediction.update(prediction_params)
+      render :show
+    else
+      render_error
+    end
+  end
+
+  private
+
+  def prediction_params
+    params.require(:prediction).permit(:choice)
+  end
+
+  def render_error
+    render json: { errors: @prediction.errors.full_messages },
+      status: :unprocessable_entity
+  end
+end

--- a/app/controllers/v1/predictions_controller.rb
+++ b/app/controllers/v1/predictions_controller.rb
@@ -2,7 +2,7 @@ class V1::PredictionsController < ApplicationController
 
   def create
     @match = Match.find(params[:match_id])
-    @predition = Predicition.new(prediction_params)
+    @predition = Prediction.new(prediction_params)
     @prediction.match = @match
     @prediction.user = current_user
     authorize @prediction
@@ -14,7 +14,7 @@ class V1::PredictionsController < ApplicationController
   end
 
   def update
-    @predition = Predicition.find_by(user: current_user, match: params[:match_id])
+    @predition = Prediction.find_by(user: current_user, match: params[:match_id])
     authorize @prediction
     if @prediction.update(prediction_params)
       render :show

--- a/app/controllers/v1/predictions_controller.rb
+++ b/app/controllers/v1/predictions_controller.rb
@@ -2,7 +2,7 @@ class V1::PredictionsController < ApplicationController
 
   def create
     @match = Match.find(params[:match_id])
-    @predition = Prediction.new(prediction_params)
+    @prediction = Prediction.new(prediction_params)
     @prediction.match = @match
     @prediction.user = current_user
     authorize @prediction

--- a/app/controllers/v1/predictions_controller.rb
+++ b/app/controllers/v1/predictions_controller.rb
@@ -14,7 +14,7 @@ class V1::PredictionsController < ApplicationController
   end
 
   def update
-    @predition = Prediction.find_by(user: current_user, match: params[:match_id])
+    @prediction = Prediction.find_by(user: current_user, match: params[:match_id])
     authorize @prediction
     if @prediction.update(prediction_params)
       render :show

--- a/app/policies/match_policy.rb
+++ b/app/policies/match_policy.rb
@@ -1,0 +1,7 @@
+class MatchPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/policies/prediction_policy.rb
+++ b/app/policies/prediction_policy.rb
@@ -4,4 +4,18 @@ class PredictionPolicy < ApplicationPolicy
       scope.all
     end
   end
+
+  def create?
+    true
+  end
+
+  def update?
+    owner_or_admin?
+  end
+
+  private
+
+  def owner_or_admin?
+    record.user == user || user.admin?
+  end
 end

--- a/app/policies/prediction_policy.rb
+++ b/app/policies/prediction_policy.rb
@@ -1,0 +1,7 @@
+class PredictionPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/policies/user/match_policy.rb
+++ b/app/policies/user/match_policy.rb
@@ -1,0 +1,7 @@
+class User::MatchPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      user.matches
+    end
+  end
+end

--- a/app/views/v1/matches/index.json.jbuilder
+++ b/app/views/v1/matches/index.json.jbuilder
@@ -1,3 +1,12 @@
 json.array! @matches do |match|
   json.extract! match, :id, :kickoff_time, :team_home_score, :team_away_score, :status, :group_id, :team_away_id, :team_home_id, :next_match_id, :round_id
+  prediction = match.predictions.find_by(user: @user)
+  if prediction
+    json.prediction do
+      json.id prediction.id
+      json.choice prediction.choice
+      json.user_id prediction.user.id
+      json.match_id prediction.match.id
+    end
+  end
 end

--- a/app/views/v1/matches/index.json.jbuilder
+++ b/app/views/v1/matches/index.json.jbuilder
@@ -1,0 +1,3 @@
+json.array! @matches do |match|
+  json.extract! match, :id, :kickoff_time, :team_home_score, :team_away_score, :status, :group_id, :team_away_id, :team_home_id, :next_match_id, :round_id
+end

--- a/app/views/v1/predictions/show.json.jbuilder
+++ b/app/views/v1/predictions/show.json.jbuilder
@@ -1,1 +1,2 @@
 json.extract! @prediction, :id, :choice, :match_id, :user_id
+

--- a/app/views/v1/predictions/show.json.jbuilder
+++ b/app/views/v1/predictions/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! @prediction, :id, :choice, :match_id, :user_id

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,7 +5,7 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = !Rails.env.development?
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'auth', controllers: {
     sessions: 'auth/devise_token_auth/sessions'
   }
-  namespace :v1 do
+  namespace :v1, defaults: { format: :json } do
     resources :competitions, only: [:show] do
       resources :leagues, only: [:index, :create]
     end

--- a/test/controllers/v1/matches_controller_test.rb
+++ b/test/controllers/v1/matches_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class V1::MatchesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/v1/predictions_controller_test.rb
+++ b/test/controllers/v1/predictions_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class V1::PredictionsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/policies/match_policy_test.rb
+++ b/test/policies/match_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class MatchPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end

--- a/test/policies/prediction_policy_test.rb
+++ b/test/policies/prediction_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class PredictionPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end

--- a/test/policies/user/match_policy_test.rb
+++ b/test/policies/user/match_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class User::MatchPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end


### PR DESCRIPTION
Added predictions and matches controller.
I found out that I'm not entirely sure how we want to format a match with a prediction. Something like?
```
{
  [
   { 
     id: 1, 
     kickoff_time: "" , 
     team_home_score: nil, 
     team_away_score: nil, 
     status: :upcoming, 
     group_id: 1, 
     team_away_id: 1, 
     team_home_id: 2, 
     next_match_id: 2, 
     round_id: 1, 
     prediction: {
       id: 1,
       choice: 'home',
       user_id: 1,
       match_id: 1
     } 
   }
   ...
  ]
}
```
So basically, if there is a prediction for that user on that match, group it together. If no prediction, leave `prediction` out? Or have id and choice nil?
Might need a clever SQL statement to group them?

As of right now, the matches controller is just rendering all of the matches.

#### ℹ️ predictions controller working fine tho 👌


Closes #21 