### PR TITLE
Memberships

### DIFF
--- a/app/controllers/v1/memberships_controller.rb
+++ b/app/controllers/v1/memberships_controller.rb
@@ -1,0 +1,14 @@
+class V1::MembershipsController < ApplicationController
+  def create
+    @leaderboard = Leaderboard.find_by(password: params[:password])
+    @membership = Membership.new
+    @membership.leaderboard = @leaderboard
+    @membership.user = current_user
+    authorize @membership
+    if @membership.save
+      render :show, status: :created
+    else
+      render_error(@membership)
+    end
+  end
+end

--- a/app/policies/membership_policy.rb
+++ b/app/policies/membership_policy.rb
@@ -1,0 +1,7 @@
+class MembershipPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/policies/membership_policy.rb
+++ b/app/policies/membership_policy.rb
@@ -4,4 +4,8 @@ class MembershipPolicy < ApplicationPolicy
       scope.all
     end
   end
+
+  def create?
+    record.leaderboard.user != user
+  end
 end

--- a/app/views/v1/memberships/_membership.json.jbuilder
+++ b/app/views/v1/memberships/_membership.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! membership, :id, :leaderboard_id, :user_id

--- a/app/views/v1/memberships/show.json.jbuilder
+++ b/app/views/v1/memberships/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! @membership, :id, :leaderboard_id, :user_id

--- a/app/views/v1/memberships/show.json.jbuilder
+++ b/app/views/v1/memberships/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! @membership, :id, :leaderboard_id, :user_id
+json.partial! @membership

--- a/app/views/v1/predictions/show.json.jbuilder
+++ b/app/views/v1/predictions/show.json.jbuilder
@@ -1,2 +1,1 @@
 json.extract! @prediction, :id, :choice, :match_id, :user_id
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,5 +14,6 @@ Rails.application.routes.draw do
       resources :memberships, only: [:create, :destroy]
     end
     resources :users, only: [:show]
+    get 'join/:password', to: 'memberships#create'
   end
 end

--- a/test/controllers/v1/memberships_controller_test.rb
+++ b/test/controllers/v1/memberships_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class V1::MembershipsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/policies/membership_policy_test.rb
+++ b/test/policies/membership_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class MembershipPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end


### PR DESCRIPTION
user can join with a unique token instead of manually entering a password

wasn't 100% sure on the route since technically the `join/:password` route will be in the front-end routes im assuming