### PR TITLE
Feature: Add teams info to matches#index and Refactor predictions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,14 @@ class ApplicationController < ActionController::API
   rescue_from Pundit::NotAuthorizedError,   with: :user_not_authorized
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
 
+  # Allows JSON compliant key names in the front-end and Ruby compliant key names in the back-end
+  before_action :underscore_params!
+
   private
+
+  def underscore_params!
+    params.deep_transform_keys!(&:underscore)
+  end
 
   def user_not_authorized(exception)
     render json: {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,14 +10,7 @@ class ApplicationController < ActionController::API
   rescue_from Pundit::NotAuthorizedError,   with: :user_not_authorized
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
 
-  # Transforms JSON key names (UpperCamelCase) to lower_snake_case
-  before_action :underscore_params!
-
   private
-
-  def underscore_params!
-    params.deep_transform_keys!(&:underscore)
-  end
 
   def user_not_authorized(exception)
     render json: {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::API
   rescue_from Pundit::NotAuthorizedError,   with: :user_not_authorized
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
 
-  # Allows JSON compliant key names in the front-end and Ruby compliant key names in the back-end
+  # Transforms JSON key names (UpperCamelCase) to lower_snake_case
   before_action :underscore_params!
 
   private

--- a/app/controllers/v1/matches_controller.rb
+++ b/app/controllers/v1/matches_controller.rb
@@ -1,12 +1,16 @@
 class V1::MatchesController < ApplicationController
-
   # /matches?competition_id=:id&user_id=:id
   def index
     @user = User.find_by(id: params[:user_id]) || current_user
     @competition = Competition.find_by(id: params[:competition_id])
     @matches =
       if @competition
-        policy_scope(Match).where(group: @competition.groups).order(:kickoff_time)
+        policy_scope(Match).joins(:team_away, :team_home)
+                           .left_outer_joins(:predictions)
+                           .includes(:team_away, :team_home, :predictions)
+                           .where(group: @competition.groups)
+                           .where('predictions.user_id = ? OR predictions.user_id IS NULL', @user.id)
+                           .order(:kickoff_time)
       else
         policy_scope([:user, Match]).order(:kickoff_time)
       end

--- a/app/views/v1/matches/index.json.jbuilder
+++ b/app/views/v1/matches/index.json.jbuilder
@@ -1,4 +1,16 @@
 json.array! @matches do |match|
-  json.extract! match, :id, :kickoff_time, :team_home_score, :team_away_score, :status, :group_id, :next_match_id, :round_id, :team_away, :team_home
-  json.prediction match.predictions.first if match.predictions.any?
+  json.extract! match, :id, :kickoff_time, :status, :group_id, :next_match_id, :round_id
+  json.team_home do
+    json.partial! match.team_home, partial: 'teams/team', as: :team
+    json.score match.team_home_score if match.team_home_score
+  end
+  json.team_away do
+    json.partial! match.team_away, partial: 'teams/team', as: :team
+    json.score match.team_away_score if match.team_away_score
+  end
+  if match.predictions.any?
+    json.prediction do
+      json.partial! match.predictions.first, partial: 'predictions/prediction', as: :prediction
+    end
+  end
 end

--- a/app/views/v1/matches/index.json.jbuilder
+++ b/app/views/v1/matches/index.json.jbuilder
@@ -8,9 +8,5 @@ json.array! @matches do |match|
     json.partial! match.team_away
     json.score match.team_away_score if match.team_away_score
   end
-  if match.predictions.any?
-    json.prediction do
-      json.partial! match.predictions.first
-    end
-  end
+  json.prediction { json.partial! match.predictions.first } if match.predictions.any?
 end

--- a/app/views/v1/matches/index.json.jbuilder
+++ b/app/views/v1/matches/index.json.jbuilder
@@ -1,16 +1,16 @@
 json.array! @matches do |match|
   json.extract! match, :id, :kickoff_time, :status, :group_id, :next_match_id, :round_id
   json.team_home do
-    json.partial! match.team_home, partial: 'teams/team', as: :team
+    json.partial! match.team_home
     json.score match.team_home_score if match.team_home_score
   end
   json.team_away do
-    json.partial! match.team_away, partial: 'teams/team', as: :team
+    json.partial! match.team_away
     json.score match.team_away_score if match.team_away_score
   end
   if match.predictions.any?
     json.prediction do
-      json.partial! match.predictions.first, partial: 'predictions/prediction', as: :prediction
+      json.partial! match.predictions.first
     end
   end
 end

--- a/app/views/v1/matches/index.json.jbuilder
+++ b/app/views/v1/matches/index.json.jbuilder
@@ -2,11 +2,11 @@ json.array! @matches do |match|
   json.extract! match, :id, :kickoff_time, :status, :group_id, :next_match_id, :round_id
   json.team_home do
     json.partial! match.team_home
-    json.score match.team_home_score if match.team_home_score
+    json.score match.team_home_score if match.finished?
   end
   json.team_away do
     json.partial! match.team_away
-    json.score match.team_away_score if match.team_away_score
+    json.score match.team_away_score if match.finished?
   end
   json.prediction { json.partial! match.predictions.first } if match.predictions.any?
 end

--- a/app/views/v1/matches/index.json.jbuilder
+++ b/app/views/v1/matches/index.json.jbuilder
@@ -1,12 +1,4 @@
 json.array! @matches do |match|
-  json.extract! match, :id, :kickoff_time, :team_home_score, :team_away_score, :status, :group_id, :team_away_id, :team_home_id, :next_match_id, :round_id
-  prediction = match.predictions.find_by(user: @user)
-  if prediction
-    json.prediction do
-      json.id prediction.id
-      json.choice prediction.choice
-      json.user_id prediction.user.id
-      json.match_id prediction.match.id
-    end
-  end
+  json.extract! match, :id, :kickoff_time, :team_home_score, :team_away_score, :status, :group_id, :next_match_id, :round_id, :team_away, :team_home
+  json.prediction match.predictions.first if match.predictions.any?
 end

--- a/app/views/v1/predictions/_prediction.json.jbuilder
+++ b/app/views/v1/predictions/_prediction.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! prediction, :id, :choice, :match_id, :user_id

--- a/app/views/v1/predictions/show.json.jbuilder
+++ b/app/views/v1/predictions/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! @prediction, partial: 'predictions/prediction', as: :prediction
+json.partial! @prediction

--- a/app/views/v1/predictions/show.json.jbuilder
+++ b/app/views/v1/predictions/show.json.jbuilder
@@ -1,2 +1,1 @@
-json.extract! @prediction, :id, :choice, :match_id, :user_id
-
+json.partial! @prediction, partial: 'predictions/prediction', as: :prediction

--- a/app/views/v1/teams/_team.json.jbuilder
+++ b/app/views/v1/teams/_team.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! team, :id, :name, :abbrev


### PR DESCRIPTION
So... I know we were not planning on refactoring the prediction yet, but I was playing around to see how I would add the teams info to the matches JSON, and it turns out it was way simpler than I thought (`includes` pretty much does all the heavy-lifting for the SQL query). So I seized the opportunity to refactor the prediction as well.

Also, sharing something pretty cool that I found out while playing around... If you have this AR relation:
```
@matches = Match.joins(:team_away, :team_home)
                .left_outer_joins(:predictions)
                .includes(:team_away, :team_home, :predictions)
                .where(group: @competition.groups)
                .where('predictions.user_id = ? OR predictions.user_id IS NULL', @user.id)
                .order(:kickoff_time)
```
You can actually include the associations when creating a `json` simply with an `include` option:
```
@matches.to_json(include: [:team_away, :team_home, :predictions]) 🤯 
```
I feel like I've just earned a couple new XP points with AR haha... I guess I didn't fully understand the purpose of `includes` until now, but this it's now definitely going to simplify my DB life :)