### PR TITLE
Fix CORS config for Netlify

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -11,7 +11,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
       # Local server
       %r{\Ahttps?://localhost:\d{4}},
       # Netlify app and preview deploys
-      %r{\Ahttps?://(.+--)?soccer-predictor.\.netlify\.app}
+      %r{\Ahttps?://(.+--)?soccer-predictor\.netlify\.app}
       # TODO: Add production domain url:
       # %r(\Ahttps?:\/\/.+\.app-name\.com),
     ]


### PR DESCRIPTION
Figured out the CORS issue on Netlify was due to a typo in the regular expression from the CORS config. This should fix it.