### PR TITLE
Fix `matches#index` to serve all matches

### DIFF
--- a/app/controllers/v1/matches_controller.rb
+++ b/app/controllers/v1/matches_controller.rb
@@ -9,6 +9,7 @@ class V1::MatchesController < ApplicationController
                            .left_outer_joins(:predictions)
                            .includes(:team_away, :team_home, :predictions)
                            .where(group: @competition.groups)
+                           .order(:kickoff_time)
 
         # TODO: Rewrite the query to avoid iterating over each match to get the predictions
 

--- a/app/controllers/v1/matches_controller.rb
+++ b/app/controllers/v1/matches_controller.rb
@@ -9,8 +9,34 @@ class V1::MatchesController < ApplicationController
                            .left_outer_joins(:predictions)
                            .includes(:team_away, :team_home, :predictions)
                            .where(group: @competition.groups)
-                           .where('predictions.user_id = ? OR predictions.user_id IS NULL', @user.id)
-                           .order(:kickoff_time)
+
+        # TODO: Rewrite the query to avoid iterating over each match to get the predictions
+
+        # # ORIGINAL ATTEMPT
+        # # The following query doesn't work because if any use makes a prediction on a match,
+        # # the predictions.user_id in the joined table is neither the current user's id, nor
+        # # is it NULL. The solution would be to make a SQL UNION query (not possible in AR).
+        # policy_scope(Match).joins(:team_away, :team_home)
+        #                    .left_outer_joins(:predictions)
+        #                    .includes(:team_away, :team_home, :predictions)
+        #                    .where(group: @competition.groups)
+        #                    .where('predictions.user_id = ? OR predictions.user_id IS NULL', @user.id)
+        #                    .order(:kickoff_time)
+
+        # # NEW ATTEMPT
+        # matches_with_predictions = policy_scope(Match).joins(:team_away, :team_home)
+        #                                               .joins(:predictions)
+        #                                               .includes(:team_away, :team_home, :predictions)
+        #                                               .where(group: @competition.groups)
+        #                                               .where('predictions.user_id = ?', @user.id)
+
+        # matches_without_predictions = policy_scope(Match).joins(:team_away, :team_home)
+        #                                                  .includes(:team_away, :team_home, :predictions)
+        #                                                  .where(group: @competition.groups)
+        #                                                  .where.not(matches: { id: matches_with_predictions })
+
+        # sql_query = "(#{matches_with_predictions.to_sql}) UNION (#{matches_without_predictions.to_sql})"
+        # policy_scope(Match).execute_sql(sql_query)
       else
         policy_scope([:user, Match]).order(:kickoff_time)
       end

--- a/app/views/v1/matches/index.json.jbuilder
+++ b/app/views/v1/matches/index.json.jbuilder
@@ -8,5 +8,6 @@ json.array! @matches do |match|
     json.partial! match.team_away
     json.score match.team_away_score if match.finished?
   end
-  json.prediction { json.partial! match.predictions.find_by(user: @user) } if match.predictions.find_by(user: @user)
+  user_prediction = match.predictions.find_by(user: @user)
+  json.prediction { json.partial! user_prediction } if user_prediction
 end

--- a/app/views/v1/matches/index.json.jbuilder
+++ b/app/views/v1/matches/index.json.jbuilder
@@ -8,5 +8,5 @@ json.array! @matches do |match|
     json.partial! match.team_away
     json.score match.team_away_score if match.finished?
   end
-  json.prediction { json.partial! match.predictions.first } if match.predictions.any?
+  json.prediction { json.partial! match.predictions.find_by(user: @user) } if match.predictions.find_by(user: @user)
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -113,10 +113,10 @@ end
 
 ScrapeMatchesService.new.call
 
-puts 'Assigning random scores to matches before June 22nd'
-Match.where('kickoff_time < ?', Date.new(2021, 6, 22)).each do |match|
-  match.update(team_away_score: rand(4), team_home_score: rand(4), status: :finished)
-end
-# Needed when migrating status enum from integer to string:
-Match.where('kickoff_time >= ?', Date.new(2021, 6, 22)).update(status: :upcoming)
-puts "...#{Match.finished.count} Finished Matches and #{Match.upcoming.count} Upcoming Matches"
+# puts 'Assigning random scores to matches before June 22nd'
+# Match.where('kickoff_time < ?', Date.new(2021, 6, 22)).each do |match|
+#   match.update(team_away_score: rand(4), team_home_score: rand(4), status: :finished)
+# end
+# # Needed when migrating status enum from integer to string:
+# Match.where('kickoff_time >= ?', Date.new(2021, 6, 22)).update(status: :upcoming)
+# puts "...#{Match.finished.count} Finished Matches and #{Match.upcoming.count} Upcoming Matches"


### PR DESCRIPTION
Found some issues with the query, but I don't think it's possible to solve with AR. Right now, matches for which you had made a prediction didn't show up for me.

I will need to make an advanced query in the future to get rid of the N+1 queries. For now, the iteration is happening when building the json.