### PR TITLE
Hide full email address from user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ApplicationRecord
   end
 
   def display_name
-    name || email
+    name || email.split('@').first
   end
 
   def score(competition)


### PR DESCRIPTION
Now that I see the leaderboards, I think it's not ideal to disclose the user's full email address if they didn't add a name.