### PR TITLE
Add Sidekiq web interface to Rails app

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,5 +37,10 @@ module PredictorApi
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
     config.active_job.queue_adapter = :sidekiq
+
+    # Adding back session middleware for Sidekiq::Web
+    config.session_store :cookie_store, key: '_interslice_session'
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use config.session_store, config.session_options
   end
 end


### PR DESCRIPTION
Resolves #70

Protects the /sidekiq route behind BasicAuth.
You can add a username and password by adding the `SIDEKIQ_USERNAME` and `SIDEKIQ_PASSWORD` env vars to Heroku.