### PR TITLE
added needed gems for Redis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,9 @@ gem 'devise_token_auth', github: 'lynndylanhurley/devise_token_auth'
 gem 'faker'
 gem 'httparty'
 gem 'omniauth'
-gem 'net-smtp'
+gem 'net-smtp', require: false
+gem 'net-imap', require: false
+gem 'net-pop', require: false
 gem 'pundit'
 gem 'rexml'
 gem 'scout_apm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,10 @@ GEM
     multi_xml (0.6.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
+    net-imap (0.3.1)
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
     net-protocol (0.1.3)
       timeout
     net-smtp (0.3.1)
@@ -313,6 +317,8 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   listen (~> 3.3)
   mailcatcher
+  net-imap
+  net-pop
   net-smtp
   omniauth
   pg (~> 1.1)


### PR DESCRIPTION
Ran into this error in production:
```
Bundler: failed to load command: sidekiq (/app/vendor/bundle/ruby/3.1.0/bin/sidekiq)
2022-11-17T23:18:16.047143+00:00 app[worker.1]: /app/vendor/bundle/ruby/3.1.0/gems/bootsnap-1.13.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:29:in `require': cannot load such file -- net/pop (LoadError)
```
So I found [this StackOverflow](https://stackoverflow.com/a/70500221/8278088) which seems to be needed to include net/pop which we're missing somehow.
