### PR TITLE
Add results to leaderboards endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,10 +35,12 @@ gem 'omniauth'
 gem 'net-smtp', require: false
 gem 'net-imap', require: false
 gem 'net-pop', require: false
+gem 'progress_bar'
 gem 'pundit'
 gem 'rexml'
 gem 'scout_apm'
 gem 'sidekiq', '~> 5.0.4'
+gem 'scenic'
 gem 'sidekiq-failures', '~> 1.0'
 gem 'watir', '6.16.5'
 gem 'webdrivers'
@@ -52,6 +54,7 @@ group :development, :test do
 end
 
 group :development do
+  gem 'bullet'
   gem 'letter_opener'
   gem 'listen', '~> 3.3'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,9 @@ GEM
     bootsnap (1.13.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    bullet (7.0.3)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     childprocess (3.0.0)
     cloudinary (1.16.1)
@@ -112,6 +115,7 @@ GEM
       thor
       tilt
     hashie (5.0.0)
+    highline (2.0.3)
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
@@ -179,10 +183,14 @@ GEM
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
       rack-protection
+    options (2.3.2)
     orm_adapter (0.5.0)
     parser (3.1.2.1)
       ast (~> 2.4.1)
     pg (1.4.4)
+    progress_bar (1.3.3)
+      highline (>= 1.6, < 3)
+      options (~> 2.3.0)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -245,6 +253,9 @@ GEM
     rexml (3.2.5)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
+    scenic (1.6.0)
+      activerecord (>= 4.0.0)
+      railties (>= 4.0.0)
     scout_apm (5.3.2)
       parser
     selenium-webdriver (3.142.7)
@@ -291,6 +302,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
+    uniform_notifier (1.16.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     watir (6.16.5)
@@ -312,6 +324,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)
+  bullet
   byebug
   cloudinary (~> 1.16.0)
   devise
@@ -328,6 +341,7 @@ DEPENDENCIES
   net-smtp
   omniauth
   pg (~> 1.1)
+  progress_bar
   pry-byebug
   puma (~> 5.0)
   pundit
@@ -335,6 +349,7 @@ DEPENDENCIES
   rails (~> 6.1.7)
   redis (~> 3.3.3)
   rexml
+  scenic
   scout_apm
   sidekiq (~> 5.0.4)
   sidekiq-failures (~> 1.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::API
   include DeviseTokenAuth::Concerns::SetUserByToken
-  include Pundit
+  include Pundit::Authorization
 
   before_action :authenticate_user!, unless: :token_auth_controller?
 

--- a/app/controllers/v1/leaderboards_controller.rb
+++ b/app/controllers/v1/leaderboards_controller.rb
@@ -1,8 +1,8 @@
 class V1::LeaderboardsController < ApplicationController
-
   def index
     @competition = Competition.find(params[:competition_id])
-    @leaderboards = policy_scope(Leaderboard).where(competition: @competition)
+    @leaderboards = policy_scope(Leaderboard).includes(:users, locked_predictions: { match: { group: :round } })
+                                             .where(competition: @competition)
   end
 
   def create

--- a/app/controllers/v1/leaderboards_controller.rb
+++ b/app/controllers/v1/leaderboards_controller.rb
@@ -1,7 +1,7 @@
 class V1::LeaderboardsController < ApplicationController
   def index
     @competition = Competition.find(params[:competition_id])
-    @leaderboards = policy_scope(Leaderboard).includes(:users, locked_predictions: { match: { group: :round } })
+    @leaderboards = policy_scope(Leaderboard).includes(:match_results, rankings: %i[user])
                                              .where(competition: @competition)
   end
 

--- a/app/controllers/v1/leaderboards_controller.rb
+++ b/app/controllers/v1/leaderboards_controller.rb
@@ -21,7 +21,8 @@ class V1::LeaderboardsController < ApplicationController
   def destroy
     @leaderboard = Leaderboard.find(params[:id])
     authorize @leaderboard
-    @leaderboard.leave(current_user)
+    membership = @leaderboard.memberships.find_by!(user: current_user)
+    membership.destroy
     head :no_content
   end
 
@@ -30,5 +31,4 @@ class V1::LeaderboardsController < ApplicationController
   def leaderboard_params
     params.require(:leaderboard).permit(:name)
   end
-
 end

--- a/app/controllers/v1/matches_controller.rb
+++ b/app/controllers/v1/matches_controller.rb
@@ -2,7 +2,7 @@ class V1::MatchesController < ApplicationController
   # /matches?competition_id=:id&user_id=:id
   def index
     @user = User.find_by(id: params[:user_id]) || current_user
-    p @competition = Competition.find_by(id: params[:competition_id])
+    @competition = Competition.find_by(id: params[:competition_id])
     skip_policy_scope
     @matches = @user.matches(competition: @competition)
   end

--- a/app/controllers/v1/matches_controller.rb
+++ b/app/controllers/v1/matches_controller.rb
@@ -2,8 +2,11 @@ class V1::MatchesController < ApplicationController
   # /matches?competition_id=:id&user_id=:id
   def index
     @user = User.find_by(id: params[:user_id]) || current_user
-    @competition = Competition.find_by(id: params[:competition_id])
-    skip_policy_scope
-    @matches = @user.matches(competition: @competition)
+    competition = Competition.find_by(id: params[:competition_id])
+    @matches = policy_scope(Match).includes(
+      :round,
+      team_home: [badge_attachment: :blob, flag_attachment: :blob],
+      team_away: [badge_attachment: :blob ,flag_attachment: :blob]
+    ).where(competition: competition)
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,11 +1,20 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
+  private
+
   def self.execute_sql(query, args = {})
     query = sanitize_sql([query, args])
     results = ActiveRecord::Base.connection.execute(query)
     return unless results.present?
 
     results
+  end
+
+  def refresh_materialized_views
+    # The materialized views need to be refreshed in this order
+    MatchResult.refresh
+    UserScore.refresh
+    LeaderboardRanking.refresh
   end
 end

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -1,22 +1,21 @@
 class Competition < ApplicationRecord
   belongs_to :current_round, class_name: 'Round', optional: true
-  has_many :rounds, dependent: :destroy
+  has_many :matches
+  has_many :rounds, -> { distinct }, through: :matches
   has_many :groups, through: :rounds
-  has_many :matches, through: :groups
   has_many :affiliations, through: :groups
   has_many :teams, through: :affiliations
   has_many :leaderboards, dependent: :destroy
   has_many :predictions, through: :matches, dependent: :destroy
+
   validates :name, presence: true, uniqueness: { scope: :start_date}
   validates :start_date, presence: true
   validates :end_date, presence: true
   scope :on_going, -> { where('start_date < :start AND end_date > :end', start: Date.today + 1, end: Date.today - 1) }
 
-  def matches
-    Match.where(group: groups).or(Match.where(round: rounds))
-  end
+  after_commit :refresh_materialized_views
 
-  def predictions
-    Prediction.where(match: matches)
+  def max_possible_score
+    matches.finished.joins(:round).sum('rounds.points')
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -5,45 +5,4 @@ class Group < ApplicationRecord
   has_many :teams, through: :affiliations
   validates :name, presence: true
   validates_uniqueness_of :name, scope: :round
-
-  RANKING_SQL = <<-SQL.freeze
-    WITH match_results AS (
-      SELECT teams.id AS team_id, matches.id AS match_id,
-      CASE -- Calculating points earned per match
-        WHEN
-          (team_home_id = teams.id AND team_home_score > team_away_score)
-          OR (team_away_id = teams.id AND team_home_score < team_away_score)
-        THEN 3
-        WHEN
-          (team_home_id = teams.id AND team_home_score < team_away_score) OR
-          (team_away_id = teams.id AND team_home_score > team_away_score)
-        THEN 0
-        ELSE 1
-      END AS result,
-      CASE -- Calculating goal difference
-        WHEN team_home_id = teams.id THEN team_home_score - team_away_score
-        ELSE team_away_score - team_home_score
-      END AS match_goal_diff
-      FROM teams
-      JOIN matches ON team_home_id = teams.id OR team_away_id = teams.id
-      WHERE status = 'finished' AND group_id = :group_id
-    )
-    SELECT teams.*, SUM(result) AS points, SUM(match_goal_diff) AS goal_diff, COUNT(*) AS matches_count
-    FROM match_results
-    JOIN teams ON team_id = teams.id
-    GROUP BY teams.id
-    ORDER BY points DESC, goal_diff DESC
-  SQL
-
-  def ranking
-    Group.execute_sql(RANKING_SQL, group_id: id)
-  end
-
-  def leader
-    Team.find(ranking.first['id'])
-  end
-
-  def runner_up
-    Team.find(ranking[1]['id'])
-  end
 end

--- a/app/models/leaderboard.rb
+++ b/app/models/leaderboard.rb
@@ -3,6 +3,7 @@ class Leaderboard < ApplicationRecord
   belongs_to :competition
   has_many :memberships, dependent: :destroy
   has_many :users, through: :memberships
+  has_many :locked_predictions, -> { locked }, through: :users, source: :predictions
   validates :name, presence: true
   has_secure_token :password
   after_create :create_owner_membership

--- a/app/models/leaderboard.rb
+++ b/app/models/leaderboard.rb
@@ -5,25 +5,18 @@ class Leaderboard < ApplicationRecord
   has_many :users, through: :memberships
   validates :name, presence: true
   has_secure_token :password
-
-  def users
-    User.includes(:memberships).where(memberships: { leaderboard: self }).or(User.where(id: user))
-  end
-
-  def leave(current_user)
-    if user == current_user
-      # remove if empty OR transfer
-      memberships.any? ? transfer_ownership : destroy
-    elsif (membership = memberships.find_by(user: current_user))
-      # remove membership if just a regular member
-      membership.destroy
-    end
-  end
+  after_create :create_owner_membership
 
   def transfer_ownership
     membership = memberships.first
     membership.destroy
     self.user = membership.user
     save
+  end
+
+  private
+
+  def create_owner_membership
+    memberships.create(user: user)
   end
 end

--- a/app/models/leaderboard.rb
+++ b/app/models/leaderboard.rb
@@ -4,9 +4,15 @@ class Leaderboard < ApplicationRecord
   has_many :memberships, dependent: :destroy
   has_many :users, through: :memberships
   has_many :locked_predictions, -> { locked }, through: :users, source: :predictions
+
+  # Scenic views
+  has_many :match_results, -> { distinct }
+  has_many :rankings, class_name: 'LeaderboardRanking'
+
   validates :name, presence: true
   has_secure_token :password
   after_create :create_owner_membership
+  after_commit :refresh_materialized_views
 
   def transfer_ownership
     membership = memberships.first

--- a/app/models/leaderboard_ranking.rb
+++ b/app/models/leaderboard_ranking.rb
@@ -1,0 +1,5 @@
+class LeaderboardRanking < ScenicViewRecord
+  belongs_to :leaderboard
+  belongs_to :competition
+  belongs_to :user
+end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -1,8 +1,9 @@
 class Match < ApplicationRecord
+  belongs_to :competition
   belongs_to :team_away, class_name: 'Team'
   belongs_to :team_home, class_name: 'Team'
   belongs_to :group, optional: true
-  belongs_to :round, optional: true
+  belongs_to :round
   belongs_to :next_match, class_name: 'Match', optional: true
   has_many :predictions, dependent: :destroy
   has_many :users, through: :predictions
@@ -10,50 +11,18 @@ class Match < ApplicationRecord
   validates :status, presence: true
   validates :api_id, uniqueness: { allow_nil: true }
   validates_uniqueness_of :kickoff_time, scope: %i[team_home team_away]
-  validate :round_xor_group
   enum status: { upcoming: 'upcoming', started: 'started', finished: 'finished' }, _default: :upcoming
 
-  def draw?
-    return unless finished?
+  # Scenic views
+  has_many :results, class_name: 'MatchResult'
 
-    team_home_score == team_away_score &&
-    team_home_et_score == team_away_et_score &&
-    team_home_ps_score == team_away_ps_score
-  end
-
-  def round
-    super || group&.round
-  end
-
-  def winner
-    return unless finished?
-    return if draw?
-
-    winner_side == 'home' ? team_home : team_away
-  end
-
-  def extra_time?
-    team_home_et_score.present? && team_away_et_score.present?
-  end
-
-  def penalties?
-    team_home_ps_score.present? && team_away_ps_score.present?
-  end
-
-  def winner_side
-    return unless finished?
-    return 'draw' if draw?
-
-    home_wins = team_home_score > team_away_score
-    home_wins = team_home_et_score > team_away_et_score if extra_time?
-    home_wins = team_home_ps_score > team_away_ps_score if penalties?
-
-    home_wins ? 'home' : 'away'
-  end
+  before_validation :set_round_and_competition, on: :create
+  after_commit :refresh_materialized_views
 
   private
 
-  def round_xor_group
-    errors.add(:round_id, 'or Group (not both) must exist') unless group_id.present? ^ round_id.present?
+  def set_round_and_competition
+    self.round ||= group&.round
+    self.competition ||= round&.competition
   end
 end

--- a/app/models/match_result.rb
+++ b/app/models/match_result.rb
@@ -1,0 +1,10 @@
+class MatchResult < ScenicViewRecord
+  belongs_to :match
+  belongs_to :group, optional: true
+  belongs_to :round
+  belongs_to :competition
+  belongs_to :team_home, class_name: 'Team'
+  belongs_to :team_away, class_name: 'Team'
+
+  enum status: { upcoming: 'upcoming', started: 'started', finished: 'finished' }
+end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -4,6 +4,7 @@ class Membership < ApplicationRecord
   has_one :competition, through: :leaderboard
   validates_uniqueness_of :user, scope: :leaderboard
   after_destroy :update_leaderboard_ownership
+  after_commit :refresh_materialized_views
 
   private
 

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -3,4 +3,13 @@ class Membership < ApplicationRecord
   belongs_to :user
   has_one :competition, through: :leaderboard
   validates_uniqueness_of :user, scope: :leaderboard
+  after_destroy :update_leaderboard_ownership
+
+  private
+
+  def update_leaderboard_ownership
+    return unless user == leaderboard.user
+    
+    leaderboard.memberships.any? ? leaderboard.transfer_ownership : leaderboard.destroy
+  end
 end

--- a/app/models/prediction.rb
+++ b/app/models/prediction.rb
@@ -4,13 +4,16 @@ class Prediction < ApplicationRecord
   belongs_to :user
   validates_uniqueness_of :user, scope: :match
   validates :choice, presence: true
-  enum choice: %i[home away draw]
+  enum choice: { home: 'home', away: 'away', draw: 'draw' }
 
   scope :locked, -> { joins(:match).where.not(matches: { status: :upcoming }) }
 
-  def correct?
-    return unless match.finished?
+  after_commit :refresh_materialized_views
 
-    choice == match.winner_side
+  private
+
+  def refresh_materialized_views
+    UserScore.refresh
+    LeaderboardRanking.refresh
   end
 end

--- a/app/models/prediction.rb
+++ b/app/models/prediction.rb
@@ -6,6 +6,8 @@ class Prediction < ApplicationRecord
   validates :choice, presence: true
   enum choice: %i[home away draw]
 
+  scope :locked, -> { joins(:match).where.not(matches: { status: :upcoming }) }
+
   def correct?
     return unless match.finished?
 

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -4,7 +4,12 @@ class Round < ApplicationRecord
   has_many :matches, through: :groups
   validates :name, presence: true, uniqueness: { scope: :competition }
 
-  def points
-    number + 2
+  before_validation :set_points, on: :create
+  after_commit :refresh_materialized_views
+
+  private
+
+  def set_points
+    self.points ||= number + 2
   end
 end

--- a/app/models/scenic_view_record.rb
+++ b/app/models/scenic_view_record.rb
@@ -1,0 +1,7 @@
+class ScenicViewRecord < ApplicationRecord
+  self.abstract_class = true
+  
+  def self.refresh
+    Scenic.database.refresh_materialized_view(table_name, concurrently: false, cascade: false)
+  end
+end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -10,26 +10,4 @@ class Team < ApplicationRecord
     # teams can either be home or away
     Match.where('team_home_id = :id OR team_away_id = :id', id: id)
   end
-
-  # These methods are not used for Group rankings, but could be used for individual team stats
-  def victories
-    matches.finished.where(<<-SQL, id: id)
-      (team_home_id = :id AND team_home_score > team_away_score) OR
-      (team_away_id = :id AND team_home_score < team_away_score)
-    SQL
-  end
-
-  def defeats
-    matches.finished.where(<<-SQL, id: id)
-      (team_home_id = :id AND team_home_score < team_away_score) OR
-      (team_away_id = :id AND team_home_score > team_away_score)
-    SQL
-  end
-
-  def draws
-    matches.finished.where(<<-SQL, id: id)
-      (team_home_id = :id OR team_away_id = :id) AND
-      team_home_score = team_away_score
-    SQL
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
     :omniauthable # :confirmable
   include DeviseTokenAuth::Concerns::User
   has_many :memberships, dependent: :destroy
-  has_many :leaderboards
+  has_many :leaderboards, through: :memberships
   # TODO: Fix this
   # has_many :competitions, through: :leaderboards
   has_many :predictions, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,80 +10,13 @@ class User < ApplicationRecord
   # has_many :competitions, through: :leaderboards
   has_many :predictions, dependent: :destroy
   has_many :matches, through: :predictions
+
+  # Scenic views
+  has_many :scores, class_name: 'UserScore'
+
   validates :name, presence: true, on: :update, if: :name_changed?
 
-  def display_name
-    name || email.split('@').first
-  end
-
-  def score(competition)
-    # TODO: user predictions should be scoped by competition => prediction -> match -> group -> round -> competition
-    # predictions.where(competition: competition).count(&:correct?) * 3
-    competition.predictions.includes(match: [:round, :group]).where(user: self).sum do |prediction|
-      prediction.correct? ? prediction.match.round.points : 0
-    end
-  end
-
-  def possible_score(competition)
-    competition.matches.where(status: 'finished').sum do |match|
-      match.round.points
-    end
-  end
-
-  def matches(competition: nil)
-    query = <<-SQL.freeze
-    WITH predictions AS (
-      SELECT *
-      FROM predictions
-      WHERE user_id = :user_id OR user_id IS NULL
-    ), team_badges AS (
-      SELECT teams.id AS team_id, asb.key as key
-      FROM teams
-      INNER JOIN active_storage_attachments asat ON asat.record_id = teams.id
-      JOIN active_storage_blobs asb ON asb.id = asat.blob_id
-      WHERE asat.name = 'badge' AND asat.record_type = 'Team'
-    ), team_flags AS (
-      SELECT teams.id AS team_id, asb.key as key
-      FROM teams
-      INNER JOIN active_storage_attachments asat ON asat.record_id = teams.id
-      JOIN active_storage_blobs asb ON asb.id = asat.blob_id
-      WHERE asat.name = 'flag' AND asat.record_type = 'Team'
-    ), team_with_images AS (
-      SELECT teams.*, team_badges.key AS badge_key, team_flags.key AS flag_key
-      FROM teams
-      LEFT JOIN team_badges ON teams.id = team_badges.team_id
-      LEFT JOIN team_flags ON teams.id = team_flags.team_id
-    )
-    SELECT
-      matches.*,
-      rounds.number AS round_number,
-      rounds.name AS round_name,
-      team_home.name AS team_home_name,
-      team_home.abbrev AS team_home_abbrev,
-      team_home.badge_key AS team_home_badge_key,
-      team_home.flag_key AS team_home_flag_key,
-      team_away.name AS team_away_name,
-      team_away.abbrev AS team_away_abbrev,
-      team_away.badge_key AS team_away_badge_key,
-      team_away.flag_key AS team_away_flag_key,
-      predictions.id AS prediction_id,
-      predictions.user_id AS prediction_user_id,
-      predictions.match_id AS prediction_match_id,
-      CASE
-        WHEN predictions.choice = 0 THEN 'home'
-        WHEN predictions.choice = 1 THEN 'away'
-        WHEN predictions.choice = 2 THEN 'draw'
-        ELSE NULL
-      END AS prediction_choice
-    FROM matches
-    LEFT JOIN groups ON matches.group_id = groups.id
-    LEFT JOIN rounds ON matches.round_id = rounds.id OR groups.round_id = rounds.id
-    JOIN team_with_images team_away ON matches.team_away_id = team_away.id
-    JOIN team_with_images team_home ON matches.team_home_id = team_home.id
-    LEFT JOIN predictions ON predictions.match_id = matches.id
-    #{'WHERE rounds.competition_id = :competition_id' if competition}
-    ORDER BY matches.kickoff_time
-    SQL
-    User.execute_sql(query, user_id: id, competition_id: competition&.id)
+  def name
+    super || email.split('@').first
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,18 +5,12 @@ class User < ApplicationRecord
     :omniauthable # :confirmable
   include DeviseTokenAuth::Concerns::User
   has_many :memberships, dependent: :destroy
+  has_many :leaderboards
   # TODO: Fix this
   # has_many :competitions, through: :leaderboards
   has_many :predictions, dependent: :destroy
   has_many :matches, through: :predictions
   validates :name, presence: true, on: :update, if: :name_changed?
-
-  def leaderboards(competition = nil)
-    # this includes creator or leaderboard and members
-    leaderboards = Leaderboard.includes(:memberships).where(memberships: { user: self }).or(Leaderboard.where(user: self))
-    leaderboards = leaderboards.where(competition: competition) if competition
-    leaderboards
-  end
 
   def display_name
     name || email.split('@').first

--- a/app/models/user_score.rb
+++ b/app/models/user_score.rb
@@ -1,0 +1,4 @@
+class UserScore < ScenicViewRecord
+  belongs_to :user
+  belongs_to :competition
+end

--- a/app/policies/leaderboard_policy.rb
+++ b/app/policies/leaderboard_policy.rb
@@ -1,7 +1,7 @@
 class LeaderboardPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      user.leaderboards
+      scope.where(user: user)
     end
   end
 

--- a/app/policies/leaderboard_policy.rb
+++ b/app/policies/leaderboard_policy.rb
@@ -1,7 +1,7 @@
 class LeaderboardPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      scope.where(user: user)
+      scope.joins(:memberships).where(memberships: { user: user })
     end
   end
 

--- a/app/policies/membership_policy.rb
+++ b/app/policies/membership_policy.rb
@@ -6,6 +6,6 @@ class MembershipPolicy < ApplicationPolicy
   end
 
   def create?
-    record.leaderboard.user != user
+    true
   end
 end

--- a/app/policies/user/match_policy.rb
+++ b/app/policies/user/match_policy.rb
@@ -1,7 +1,0 @@
-class User::MatchPolicy < ApplicationPolicy
-  class Scope < Scope
-    def resolve
-      user.matches
-    end
-  end
-end

--- a/app/views/v1/leaderboards/_predictions.json.jbuilder
+++ b/app/views/v1/leaderboards/_predictions.json.jbuilder
@@ -1,0 +1,5 @@
+json.set! result.match_id do
+  json.home result.predicted_home
+  json.draw result.predicted_draw
+  json.away result.predicted_away
+end

--- a/app/views/v1/leaderboards/_ranking.json.jbuilder
+++ b/app/views/v1/leaderboards/_ranking.json.jbuilder
@@ -1,0 +1,9 @@
+json.user_id ranking.user_id
+json.name ranking.user.name
+json.photo_key ranking.user.photo_key
+json.points ranking.score
+json.total_predictions ranking.total_predictions
+json.completed_predictions ranking.completed_predictions
+json.correct_predictions ranking.correct_predictions
+json.accuracy ranking.accuracy
+json.rank ranking.user_rank

--- a/app/views/v1/leaderboards/index.json.jbuilder
+++ b/app/views/v1/leaderboards/index.json.jbuilder
@@ -1,15 +1,11 @@
 json.array! @leaderboards do |leaderboard|
-  json.partial! 'v1/leaderboards/leaderboard', leaderboard: leaderboard
-  json.users leaderboard.users do |user|
-    json.user_id user.id
-    json.name user.display_name
-    json.points user.score(leaderboard.competition)
-    json.photo_key user.photo_key
+  json.partial! leaderboard
+  json.users leaderboard.rankings do |ranking|
+    json.partial! 'v1/leaderboards/ranking', ranking: ranking
   end
   json.results do
-    results = leaderboard.locked_predictions.order('matches.kickoff_time DESC').group_by(&:match_id).transform_values do |match_predictions|
-      match_predictions.group_by(&:choice).transform_values! { |c| c.map(&:user_id) }
+    leaderboard.match_results.each do |result|
+      json.partial! 'v1/leaderboards/predictions', result: result
     end
-    json.merge! results
   end
 end

--- a/app/views/v1/leaderboards/index.json.jbuilder
+++ b/app/views/v1/leaderboards/index.json.jbuilder
@@ -1,11 +1,15 @@
 json.array! @leaderboards do |leaderboard|
-  json.partial! leaderboard
+  json.partial! 'v1/leaderboards/leaderboard', leaderboard: leaderboard
   json.users leaderboard.users do |user|
     json.user_id user.id
     json.name user.display_name
     json.points user.score(leaderboard.competition)
     json.photo_key user.photo_key
   end
+  json.results do
+    results = leaderboard.locked_predictions.order('matches.kickoff_time DESC').group_by(&:match_id).transform_values do |match_predictions|
+      match_predictions.group_by(&:choice).transform_values! { |c| c.map(&:user_id) }
+    end
+    json.merge! results
+  end
 end
-
-# TODO: add 🔼 or 🔽

--- a/app/views/v1/matches/_match.json.jbuilder
+++ b/app/views/v1/matches/_match.json.jbuilder
@@ -1,0 +1,18 @@
+json.extract! match, :id, :kickoff_time, :status, :group_id, :next_match_id, :round_id, :location
+json.round_number match.round.number
+json.team_home do
+  json.partial! match.team_home
+  if match.status == 'finished'
+    json.score match.team_home_score
+    json.et_score match.team_home_et_score
+    json.ps_score match.team_home_ps_score
+  end
+end
+json.team_away do
+  json.partial! match.team_away
+  if match.status == 'finished'
+    json.score match.team_away_score 
+    json.et_score match.team_away_et_score
+    json.ps_score match.team_away_ps_score
+  end
+end

--- a/app/views/v1/matches/index.json.jbuilder
+++ b/app/views/v1/matches/index.json.jbuilder
@@ -1,36 +1,7 @@
 json.array! @matches do |match|
-  match.symbolize_keys!
-  json.merge! match.slice(:id, :kickoff_time, :status, :group_id, :next_match_id, :round_id, :location, :round_number)
-  json.team_home do
-    json.id match[:team_home_id]
-    json.name match[:team_home_name]
-    json.abbrev match[:team_home_abbrev]
-    json.badge_url cl_image_path(match[:team_home_badge_key])
-    json.flag_url cl_image_path(match[:team_home_flag_key])
-    if match[:status] == 'finished'
-      json.score match[:team_home_score]
-      json.et_score match[:team_home_et_score]
-      json.ps_score match[:team_home_ps_score]
-    end
-  end
-  json.team_away do
-    json.id match[:team_away_id]
-    json.name match[:team_away_name]
-    json.abbrev match[:team_away_abbrev]
-    json.badge_url cl_image_path(match[:team_away_badge_key])
-    json.flag_url cl_image_path(match[:team_away_flag_key])
-    if match[:status] == 'finished'
-      json.score match[:team_away_score] 
-      json.et_score match[:team_away_et_score]
-      json.ps_score match[:team_away_ps_score]
-    end
-  end
-  if match[:prediction_choice]
-    json.prediction do
-      json.id match[:prediction_id]
-      json.choice match[:prediction_choice]
-      json.user_id match[:prediction_user_id]
-      json.match_id match[:prediction_match_id]
-    end
+  json.partial! match
+  json.prediction do
+    prediction = match.predictions.find_by(user: @user)
+    json.partial! prediction if prediction.present?
   end
 end

--- a/app/views/v1/predictions/_prediction.json.jbuilder
+++ b/app/views/v1/predictions/_prediction.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! prediction, :id, :choice, :match_id, :user_id, :correct?
+json.extract! prediction, :id, :choice, :match_id, :user_id

--- a/app/views/v1/users/_user.json.jbuilder
+++ b/app/views/v1/users/_user.json.jbuilder
@@ -1,2 +1,1 @@
-json.extract! user, :id, :email, :timezone, :admin, :photo_key
-json.name user.display_name
+json.extract! user, :id, :email, :timezone, :admin, :photo_key, :name

--- a/app/views/v1/users/show.json.jbuilder
+++ b/app/views/v1/users/show.json.jbuilder
@@ -1,3 +1,6 @@
 json.partial! @user
-json.points @user.score(@competition) if @competition
-json.possible_points @user.possible_score(@competition) if @competition
+if @competition
+  json.points @user.scores.find_by(competition: @competition).score
+  json.accuracy @user.scores.find_by(competition: @competition).accuracy.to_f
+  json.possible_points @competition.max_possible_score
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,12 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.console       = true
+    Bullet.rails_logger  = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -10,6 +10,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     origins [
       # Local server
       %r{\Ahttps?://localhost:\d{4}},
+      %r{\Ahttps?://192\.168\.\d\.\d{1,3}:\d{4}},
       # Netlify app and preview deploys
       %r{\Ahttps?://(.+--)?octacle\.netlify\.app},
       # Production app

--- a/db/migrate/20221204113607_add_competition_and_round_to_matches.rb
+++ b/db/migrate/20221204113607_add_competition_and_round_to_matches.rb
@@ -1,0 +1,22 @@
+class AddCompetitionAndRoundToMatches < ActiveRecord::Migration[6.1]
+  def up
+    add_reference :matches, :competition, foreign_key: true
+
+    Match.reset_column_information
+    Match.find_each do |match|
+      match.update_columns(round_id: match.group.round.id) if match.round.blank?
+      match.update_columns(competition_id: match.round.competition.id) if match.competition.blank?
+    end
+
+    change_column_null :matches, :competition_id, false
+    change_column_null :matches, :round_id, false
+  end
+
+  def down
+    remove_reference :matches, :competition, foreign_key: true
+    change_column_null :matches, :round_id, true
+    Match.where.not(group: nil).find_each do |match|
+      match.update_columns(round_id: nil)
+    end
+  end
+end

--- a/db/migrate/20221204123021_add_points_to_rounds.rb
+++ b/db/migrate/20221204123021_add_points_to_rounds.rb
@@ -1,0 +1,15 @@
+class AddPointsToRounds < ActiveRecord::Migration[6.1]
+  def up
+    add_column :rounds, :points, :integer
+
+    Round.find_each do |round|
+      round.update_columns(points: round.number + 2)
+    end
+
+    change_column_null :rounds, :points, false
+  end
+
+  def down
+    remove_column :rounds, :points
+  end
+end

--- a/db/migrate/20221204123938_change_predictions_choice_to_string.rb
+++ b/db/migrate/20221204123938_change_predictions_choice_to_string.rb
@@ -1,0 +1,33 @@
+class ChangePredictionsChoiceToString < ActiveRecord::Migration[6.1]
+  def up
+    rename_column :predictions, :choice, :choice_integer
+    add_column :predictions, :choice, :string
+
+    say_with_time "Converting integer enum to string" do
+      predictions = Prediction.where.not(choice_integer: nil)
+      bar = ProgressBar.new(predictions.count)
+      predictions.find_each do |prediction|
+        prediction.update_columns(choice: %w[home away draw][prediction.choice_integer])
+        bar.increment!
+      end
+    end
+
+    remove_column :predictions, :choice_integer
+  end
+
+  def down
+    rename_column :predictions, :choice, :choice_string
+    add_column :predictions, :choice, :integer
+
+    say_with_time "Converting string enum to integer" do
+      predictions = Prediction.where.not(choice_string: nil)
+      bar = ProgressBar.new(predictions.count)
+      predictions.find_each do |prediction|
+        prediction.update_columns(choice: %w[home away draw].index(prediction.choice_string))
+        bar.increment!
+      end
+    end
+
+    remove_column :predictions, :choice_string
+  end
+end

--- a/db/migrate/20221204123940_create_match_results.rb
+++ b/db/migrate/20221204123940_create_match_results.rb
@@ -1,0 +1,5 @@
+class CreateMatchResults < ActiveRecord::Migration[6.1]
+  def change
+    create_view :match_results, materialized: true
+  end
+end

--- a/db/migrate/20221204124451_create_user_scores.rb
+++ b/db/migrate/20221204124451_create_user_scores.rb
@@ -1,0 +1,5 @@
+class CreateUserScores < ActiveRecord::Migration[6.1]
+  def change
+    create_view :user_scores, materialized: true
+  end
+end

--- a/db/migrate/20221204153322_create_leaderboard_rankings.rb
+++ b/db/migrate/20221204153322_create_leaderboard_rankings.rb
@@ -1,0 +1,5 @@
+class CreateLeaderboardRankings < ActiveRecord::Migration[6.1]
+  def change
+    create_view :leaderboard_rankings, materialized: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_08_131452) do
+ActiveRecord::Schema.define(version: 2022_12_04_153322) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "active_storage_attachments", force: :cascade do |t|
@@ -94,13 +95,15 @@ ActiveRecord::Schema.define(version: 2022_11_08_131452) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "next_match_id"
-    t.bigint "round_id"
+    t.bigint "round_id", null: false
     t.integer "api_id"
     t.string "location"
     t.integer "team_home_et_score"
     t.integer "team_away_et_score"
     t.integer "team_home_ps_score"
     t.integer "team_away_ps_score"
+    t.bigint "competition_id", null: false
+    t.index ["competition_id"], name: "index_matches_on_competition_id"
     t.index ["group_id"], name: "index_matches_on_group_id"
     t.index ["next_match_id"], name: "index_matches_on_next_match_id"
     t.index ["round_id"], name: "index_matches_on_round_id"
@@ -118,11 +121,11 @@ ActiveRecord::Schema.define(version: 2022_11_08_131452) do
   end
 
   create_table "predictions", force: :cascade do |t|
-    t.integer "choice"
     t.bigint "match_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "choice"
     t.index ["match_id"], name: "index_predictions_on_match_id"
     t.index ["user_id"], name: "index_predictions_on_user_id"
   end
@@ -134,6 +137,7 @@ ActiveRecord::Schema.define(version: 2022_11_08_131452) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "api_name"
+    t.integer "points", null: false
     t.index ["competition_id"], name: "index_rounds_on_competition_id"
   end
 
@@ -184,6 +188,7 @@ ActiveRecord::Schema.define(version: 2022_11_08_131452) do
   add_foreign_key "groups", "rounds"
   add_foreign_key "leaderboards", "competitions"
   add_foreign_key "leaderboards", "users"
+  add_foreign_key "matches", "competitions"
   add_foreign_key "matches", "groups"
   add_foreign_key "matches", "matches", column: "next_match_id"
   add_foreign_key "matches", "rounds"
@@ -194,4 +199,119 @@ ActiveRecord::Schema.define(version: 2022_11_08_131452) do
   add_foreign_key "predictions", "matches"
   add_foreign_key "predictions", "users"
   add_foreign_key "rounds", "competitions"
+
+  create_view "match_results", materialized: true, sql_definition: <<-SQL
+      WITH leaderboard_users AS (
+           SELECT leaderboards.id,
+              mb.user_id
+             FROM (leaderboards
+               JOIN memberships mb ON ((mb.leaderboard_id = leaderboards.id)))
+          )
+   SELECT matches.id AS match_id,
+      matches.round_id,
+      matches.competition_id,
+      l.id AS leaderboard_id,
+      matches.status,
+      matches.group_id,
+      matches.team_away_id,
+      matches.team_home_id,
+      matches.next_match_id,
+          CASE
+              WHEN (((matches.status)::text = 'upcoming'::text) OR ((matches.status)::text = 'started'::text)) THEN NULL::text
+              WHEN ((matches.team_home_et_score IS NULL) AND (matches.team_away_et_score IS NULL) AND (matches.team_home_ps_score IS NULL) AND (matches.team_away_ps_score IS NULL) AND (matches.team_home_score = matches.team_away_score)) THEN 'draw'::text
+              WHEN ((matches.team_home_score > matches.team_away_score) OR ((matches.team_home_et_score IS NOT NULL) AND (matches.team_home_et_score > matches.team_away_et_score)) OR ((matches.team_home_ps_score IS NOT NULL) AND (matches.team_home_ps_score > matches.team_away_ps_score))) THEN 'home'::text
+              ELSE 'away'::text
+          END AS winning_side,
+      r.number AS round_number,
+      r.points,
+      r.name AS round_name,
+      ARRAY( SELECT DISTINCT p.user_id
+             FROM predictions p
+            WHERE ((p.match_id = matches.id) AND (p.user_id IN ( SELECT lu.user_id
+                     FROM leaderboard_users lu
+                    WHERE (lu.id = l.id))) AND ((p.choice)::text = 'home'::text))) AS predicted_home,
+      ARRAY( SELECT DISTINCT p.user_id
+             FROM predictions p
+            WHERE ((p.match_id = matches.id) AND (p.user_id IN ( SELECT lu.user_id
+                     FROM leaderboard_users lu
+                    WHERE (lu.id = l.id))) AND ((p.choice)::text = 'draw'::text))) AS predicted_draw,
+      ARRAY( SELECT DISTINCT p.user_id
+             FROM predictions p
+            WHERE ((p.match_id = matches.id) AND (p.user_id IN ( SELECT lu.user_id
+                     FROM leaderboard_users lu
+                    WHERE (lu.id = l.id))) AND ((p.choice)::text = 'away'::text))) AS predicted_away
+     FROM ((matches
+       JOIN rounds r ON ((matches.round_id = r.id)))
+       JOIN leaderboards l ON ((l.competition_id = matches.competition_id)))
+    ORDER BY matches.id;
+  SQL
+  create_view "user_scores", materialized: true, sql_definition: <<-SQL
+      WITH prediction_scores AS (
+           SELECT DISTINCT p.id AS prediction_id,
+              p.user_id,
+              p.match_id,
+              r.points,
+              mr.competition_id,
+                  CASE
+                      WHEN (((mr.status)::text = 'finished'::text) AND (p.choice IS NOT NULL)) THEN true
+                      ELSE false
+                  END AS completed,
+                  CASE
+                      WHEN (((mr.status)::text = 'finished'::text) AND ((p.choice)::text = mr.winning_side)) THEN true
+                      ELSE false
+                  END AS correct,
+                  CASE
+                      WHEN (((mr.status)::text = 'finished'::text) AND ((p.choice)::text = mr.winning_side)) THEN mr.points
+                      ELSE 0
+                  END AS prediction_score
+             FROM ((predictions p
+               LEFT JOIN match_results mr ON ((mr.match_id = p.match_id)))
+               LEFT JOIN rounds r ON ((r.id = mr.round_id)))
+          ), prediction_numbers AS (
+           SELECT u.id AS user_id,
+              ps_1.competition_id,
+              sum(ps_1.prediction_score) AS score,
+              count(DISTINCT ps_1.prediction_id) AS total_predictions,
+              ( SELECT count(DISTINCT ps2.prediction_id) AS count
+                     FROM prediction_scores ps2
+                    WHERE (ps2.completed IS TRUE)
+                    GROUP BY ps2.user_id, ps2.competition_id
+                   HAVING ((ps2.user_id = u.id) AND (ps2.competition_id = ps_1.competition_id))) AS completed_predictions,
+              ( SELECT count(DISTINCT ps2.prediction_id) AS count
+                     FROM prediction_scores ps2
+                    WHERE (ps2.correct IS TRUE)
+                    GROUP BY ps2.user_id, ps2.competition_id
+                   HAVING ((ps2.user_id = u.id) AND (ps2.competition_id = ps_1.competition_id))) AS correct_predictions
+             FROM (users u
+               LEFT JOIN prediction_scores ps_1 ON ((ps_1.user_id = u.id)))
+            GROUP BY u.id, ps_1.competition_id
+          )
+   SELECT DISTINCT ON (ps.user_id, ps.competition_id) ps.user_id,
+      ps.competition_id,
+      pn.score,
+      (pn.completed_predictions * ps.points) AS max_possible_score,
+      pn.total_predictions,
+      pn.completed_predictions,
+      pn.correct_predictions,
+      round((((pn.correct_predictions)::numeric * 1.0) / (NULLIF(pn.total_predictions, 0))::numeric), 3) AS accuracy
+     FROM (prediction_scores ps
+       JOIN prediction_numbers pn ON (((pn.user_id = ps.user_id) AND (pn.competition_id = ps.competition_id))))
+    ORDER BY ps.user_id;
+  SQL
+  create_view "leaderboard_rankings", materialized: true, sql_definition: <<-SQL
+      SELECT DISTINCT ON ((rank() OVER (PARTITION BY l.id ORDER BY us.score DESC, us.accuracy DESC, us.completed_predictions DESC)), us.score, us.accuracy, us.completed_predictions, l.id, l.competition_id, us.user_id) l.id AS leaderboard_id,
+      us.user_id,
+      us.competition_id,
+      us.score,
+      us.max_possible_score,
+      us.total_predictions,
+      us.completed_predictions,
+      us.correct_predictions,
+      us.accuracy,
+      rank() OVER (PARTITION BY l.id ORDER BY us.score DESC, us.accuracy DESC, us.completed_predictions DESC) AS user_rank
+     FROM ((leaderboards l
+       JOIN memberships m ON ((m.leaderboard_id = l.id)))
+       JOIN user_scores us ON (((us.user_id = m.user_id) AND (us.competition_id = l.competition_id))))
+    ORDER BY (rank() OVER (PARTITION BY l.id ORDER BY us.score DESC, us.accuracy DESC, us.completed_predictions DESC)), us.score, us.accuracy, us.completed_predictions;
+  SQL
 end

--- a/db/views/leaderboard_rankings_v01.sql
+++ b/db/views/leaderboard_rankings_v01.sql
@@ -1,0 +1,11 @@
+SELECT DISTINCT ON (l.id, l.competition_id, us.user_id, user_rank, us.score, us.accuracy, us.completed_predictions)
+	l.id AS leaderboard_id,
+	us.*,
+	RANK () OVER (
+		PARTITION BY l.id
+		ORDER BY us.score DESC, us.accuracy DESC, us.completed_predictions DESC
+	) user_rank
+FROM leaderboards l 
+JOIN memberships m ON m.leaderboard_id  = l.id
+JOIN user_scores us ON us.user_id = m.user_id AND us.competition_id = l.competition_id 
+ORDER BY user_rank, us.score, us.accuracy, us.completed_predictions

--- a/db/views/match_results_v01.sql
+++ b/db/views/match_results_v01.sql
@@ -1,0 +1,45 @@
+WITH leaderboard_users AS (
+	SELECT
+		leaderboards.id,
+		mb.user_id
+	FROM leaderboards
+	JOIN memberships mb ON mb.leaderboard_id = leaderboards.id
+)
+SELECT
+	matches.id AS match_id,
+	matches.round_id,
+	matches.competition_id,
+	l.id AS leaderboard_id,
+	matches.status,
+	matches.group_id,
+	matches.team_away_id,
+	matches.team_home_id,
+	matches.next_match_id,
+	(
+		CASE
+	    WHEN (status = 'upcoming' OR status = 'started') THEN NULL
+	    WHEN (
+        team_home_et_score IS NULL AND
+        team_away_et_score IS NULL AND
+        team_home_ps_score IS NULL AND
+        team_away_ps_score IS NULL AND
+		    team_home_score = team_away_score
+	  	) THEN 'draw'
+	    WHEN (
+		    team_home_score > team_away_score OR
+		    (team_home_et_score IS NOT NULL AND team_home_et_score > team_away_et_score) OR
+		    (team_home_ps_score IS NOT NULL AND team_home_ps_score > team_away_ps_score)
+		) THEN 'home'
+		ELSE 'away'
+		END
+	) AS winning_side,
+	r.number AS round_number,
+	r.points AS points,
+	r.name AS round_name,
+	ARRAY(SELECT DISTINCT p.user_id FROM predictions p WHERE p.match_id = matches.id AND p.user_id IN (SELECT user_id FROM leaderboard_users lu WHERE lu.id = l.id) AND p.choice = 'home') as predicted_home,
+	ARRAY(SELECT DISTINCT p.user_id FROM predictions p WHERE p.match_id = matches.id AND p.user_id IN (SELECT user_id FROM leaderboard_users lu WHERE lu.id = l.id) AND p.choice = 'draw') as predicted_draw,
+	ARRAY(SELECT DISTINCT p.user_id FROM predictions p WHERE p.match_id = matches.id AND p.user_id IN (SELECT user_id FROM leaderboard_users lu WHERE lu.id = l.id) AND p.choice = 'away') as predicted_away
+FROM matches
+JOIN rounds r ON matches.round_id = r.id
+JOIN leaderboards l ON l.competition_id = matches.competition_id
+ORDER BY matches.id

--- a/db/views/user_scores_v01.sql
+++ b/db/views/user_scores_v01.sql
@@ -1,0 +1,64 @@
+WITH prediction_scores AS (
+	SELECT
+		DISTINCT p.id AS prediction_id,
+		p.user_id,
+		p.match_id,
+		r.points,
+		mr.competition_id,
+		(
+			CASE
+			WHEN mr.status = 'finished' AND p.choice IS NOT NULL THEN TRUE
+			ELSE FALSE
+			END
+		) AS completed,
+		(
+			CASE
+			WHEN mr.status = 'finished' AND p.choice = mr.winning_side THEN TRUE
+			ELSE FALSE
+			END
+		) AS correct,
+		(
+			CASE
+			WHEN mr.status = 'finished' AND p.choice = mr.winning_side THEN mr.points
+			ELSE 0
+			END
+		) AS prediction_score
+	FROM predictions p
+	LEFT JOIN match_results mr ON mr.match_id = p.match_id
+	LEFT JOIN rounds r ON r.id = mr.round_id
+), prediction_numbers AS (
+	SELECT
+		u.id AS user_id,
+		ps.competition_id,
+		SUM(ps.prediction_score) AS score,
+		COUNT(DISTINCT ps.prediction_id) AS total_predictions,
+		(
+			SELECT COUNT(DISTINCT ps2.prediction_id)
+			FROM prediction_scores ps2
+			WHERE ps2.completed IS TRUE
+			GROUP BY ps2.user_id, ps2.competition_id
+			HAVING ps2.user_id = u.id AND ps2.competition_id = ps.competition_id
+		) AS completed_predictions,
+		(
+			SELECT COUNT(DISTINCT ps2.prediction_id)
+			FROM prediction_scores ps2
+			WHERE ps2.correct IS TRUE
+			GROUP BY ps2.user_id, ps2.competition_id
+			HAVING ps2.user_id = u.id AND ps2.competition_id = ps.competition_id
+		) AS correct_predictions
+	FROM users u
+	LEFT JOIN prediction_scores ps ON ps.user_id = u.id
+	GROUP BY u.id, ps.competition_id
+)
+SELECT DISTINCT ON (ps.user_id, ps.competition_id)
+	ps.user_id,
+	ps.competition_id,
+	pn.score,
+	pn.completed_predictions * ps.points AS max_possible_score,
+	pn.total_predictions,
+	pn.completed_predictions,
+	pn.correct_predictions,
+	ROUND(pn.correct_predictions * 1.0 / NULLIF(pn.total_predictions, 0), 3) AS accuracy
+FROM prediction_scores ps
+JOIN prediction_numbers pn ON pn.user_id = ps.user_id AND pn.competition_id = ps.competition_id
+ORDER BY ps.user_id


### PR DESCRIPTION
This PR implements the following work:
- Refactor leaderboard owner to have a normal membership association. This simplifies dealing with leaderboard members and speeds up leaderboard endpoints.
- Implements a `results` hash in the leaderboard response object, containing the IDs of users based on their prediction for each match ID. These predictions are included for all "locked" games (= games that have been started or completed).

As a post-deploy task, this needs to be run in the Heroku console after deployment to create the memberships for the leaderboard owners:
```
Leaderboard.find_each { |leaderboard| leaderboard.memberships.create(user: leaderboard.user) }
```

Fixes #98 
