### PR TITLE
cache user.matches query and expire on prediction update

### DIFF
--- a/app/models/prediction.rb
+++ b/app/models/prediction.rb
@@ -1,7 +1,7 @@
 class Prediction < ApplicationRecord
   belongs_to :match
   has_one :competition, through: :match
-  belongs_to :user
+  belongs_to :user, touch: true
   validates_uniqueness_of :user, scope: :match
   validates :choice, presence: true
   enum choice: %i[home away draw]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,6 +37,14 @@ class User < ApplicationRecord
   end
 
   def matches(competition: nil)
+    Rails.cache.fetch("#{cache_key_with_version}-user-#{id}") do
+      execute_matches_query(competition: competition).to_a
+    end
+  end
+
+  private
+
+  def execute_matches_query(competition: nil)
     query = <<-SQL.freeze
     WITH predictions AS (
       SELECT *
@@ -92,4 +100,6 @@ class User < ApplicationRecord
     SQL
     User.execute_sql(query, user_id: id, competition_id: competition&.id)
   end
+
+  
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,7 +22,9 @@ Rails.application.configure do
       'Cache-Control' => "public, max-age=#{2.days.to_i}"
     }
   else
-    config.action_controller.perform_caching = false
+
+    # for testing expensive queries in development
+    config.action_controller.perform_caching = true
 
     config.cache_store = :null_store
   end
@@ -41,7 +43,6 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # for running expensive queries from cache
-  config.action_controller.perform_caching = true
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,6 +40,9 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  # for running expensive queries from cache
+  config.action_controller.perform_caching = true
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 


### PR DESCRIPTION
Added low-level caching to cache the result of the @user.matches query and storing it's result in a cache key based on rails `cache_key_with_version` method as detailed [here](https://guides.rubyonrails.org/caching_with_rails.html#low-level-caching). 

Also added `belongs_to :user, touch: true` in Prediction model so that cache key will be invalidated on changes to prediction user updated_at attribute will be changed which affects value of `cache_key_with_version` 