### PR TITLE
Remove callback definition in Prediction

### DIFF
--- a/app/controllers/v1/predictions_controller.rb
+++ b/app/controllers/v1/predictions_controller.rb
@@ -1,5 +1,4 @@
 class V1::PredictionsController < ApplicationController
-
   def create
     @match = Match.find(params[:match_id])
     @prediction = Prediction.new(prediction_params)

--- a/app/models/prediction.rb
+++ b/app/models/prediction.rb
@@ -9,11 +9,4 @@ class Prediction < ApplicationRecord
   scope :locked, -> { joins(:match).where.not(matches: { status: :upcoming }) }
 
   after_commit :refresh_materialized_views
-
-  private
-
-  def refresh_materialized_views
-    UserScore.refresh
-    LeaderboardRanking.refresh
-  end
 end


### PR DESCRIPTION
Sorry, I realized I forgot to remove a custom callback definition I had added for the Prediction model. Removing it as it slows down updating the predictions.