### PR TITLE
api match creator fixed for finding round

### DIFF
--- a/app/jobs/match_update_future_job.rb
+++ b/app/jobs/match_update_future_job.rb
@@ -32,7 +32,7 @@ class MatchUpdateFutureJob < ApplicationJob
         if %w[1 2 3].include?(match_info['round'])
           match.group = @competition.groups.find_by(api_id: match_info["group_id"])
         else
-          match.round = @competition.rounds.find_by(api_name: match_info['round'])
+          match.round = Round.find_by(competition: @competition, api_name: match_info['round'])
         end
         match.api_id = match_info['id']
         match.location = match_info['location']


### PR DESCRIPTION
It’s coming form [this PR](https://github.com/dmbf29/predictor-api/pull/101) which changed `has_many :rounds`
to only ones that have matches so the API match creator can’t find the next rounds anymore