### PR TITLE
Adding Euros 2024

### DIFF
--- a/app/jobs/attach_flags_job.rb
+++ b/app/jobs/attach_flags_job.rb
@@ -1,0 +1,23 @@
+class AttachFlagsJob < ApplicationJob
+  queue_as :default
+
+  def perform(competition_id)
+    competition = Competition.find(competition_id)
+    url = DataFootballApi.teams_url(competition.api_code)
+    response = HTTParty.get(
+      url,
+      headers: {
+        'Content-Type' => 'application/json',
+        'X-Auth-Token' => ENV['FOOTBALL_DATA_TOKEN']
+      }
+    ).body
+    teams = JSON.parse(response)['teams']
+    teams.each do |team_hash|
+      team = Team.find_by(abbrev: team_hash['tla'])
+      puts "#{team.name}: #{team_hash['crest']}"
+      team.flag.attach(io: URI.open(team_hash['crest']), filename: 'flag.png', content_type: 'image/png') unless team.flag.attached?
+      team.badge.attach(io: URI.open(team_hash['crest']), filename: 'badge.png', content_type: 'image/png') unless team.badge.attached?
+      puts team.flag.attached? ? 'Success' : 'Failed'
+    end
+  end
+end

--- a/app/jobs/match_update_job.rb
+++ b/app/jobs/match_update_job.rb
@@ -1,0 +1,45 @@
+class MatchUpdateJob < ApplicationJob
+  queue_as :default
+
+  def perform(competition_id)
+    @competition = Competition.find(competition_id)
+    url_to_update = DataFootballApi.matches_url(@competition.api_code)
+    update_matches_future(url_to_update)
+  end
+
+  def update_matches_future(url)
+    response = HTTParty.get(
+      url,
+      headers: {
+        'Content-Type' => 'application/json',
+        'X-Auth-Token' => ENV['FOOTBALL_DATA_TOKEN']
+      }
+    ).body
+    parsed_response = JSON.parse(response)
+    matches = parsed_response['matches']
+    DatabaseViews.run_without_callback(then_refresh: true) do
+      matches.each do |match_info|
+        kickoff_time = DateTime.parse(match_info['utcDate'])
+        puts "Finding the match between : #{match_info['homeTeam']['name']} v #{match_info['awayTeam']['name']} (#{kickoff_time})"
+        team_home = Team.find_by(abbrev: match_info['homeTeam']['tla'])
+        team_away = Team.find_by(abbrev: match_info['awayTeam']['tla'])
+        match =
+        @competition.matches.where(team_home: team_home, team_away: team_away)
+        .find_by(kickoff_time: kickoff_time) || Match.new
+        match.team_home ||= team_home
+        match.team_away ||= team_away
+        next unless match.team_home && match.team_away # knock-out rounds with no teams yet
+
+        match.round = Round.find_by(competition: @competition, api_name: match_info['stage'])
+        match.group = Group.find_by(round: match.round, api_code: match_info["group"]) if match_info["group"]
+        match.api_id = match_info['id']
+        # TODO: Don't think we're getting the location from the API
+        # match.location = match_info['location']
+        match.kickoff_time = kickoff_time
+        match.save
+        p match.errors.full_messages if match.errors.any?
+        puts 'Match Update'
+      end
+    end
+  end
+end

--- a/app/jobs/match_update_job.rb
+++ b/app/jobs/match_update_job.rb
@@ -38,6 +38,9 @@ class MatchUpdateJob < ApplicationJob
         match.kickoff_time = kickoff_time
         match.save
         p match.errors.full_messages if match.errors.any?
+
+        # Update scores
+        match.update_with_api(match_info)
         puts 'Match Update'
       end
     end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -35,6 +35,7 @@ class Match < ApplicationRecord
     self.team_away_et_score = match_info['score']['extraTime']['away'] if match_info['score']['extraTime']
     self.team_home_ps_score = match_info['score']['penalties']['home'] if match_info['score']['penalties']
     self.team_away_ps_score = match_info['score']['penalties']['away'] if match_info['score']['penalties']
+    # TODO: I'm not sure how we're displaying the scores in the view
     save
 
     scores = ["FT Score > #{build_regular_time_score}"]

--- a/app/services/data_football_api.rb
+++ b/app/services/data_football_api.rb
@@ -1,0 +1,5 @@
+class DataFootballApi
+  def self.matches_url(competition_api_code)
+    "https://api.football-data.org/v4/competitions/#{competition_api_code}/matches"
+  end
+end

--- a/app/services/data_football_api.rb
+++ b/app/services/data_football_api.rb
@@ -2,4 +2,8 @@ class DataFootballApi
   def self.matches_url(competition_api_code)
     "https://api.football-data.org/v4/competitions/#{competition_api_code}/matches"
   end
+
+  def self.teams_url(competition_api_code)
+    "https://api.football-data.org/v4/competitions/#{competition_api_code}/teams"
+  end
 end

--- a/db/migrate/20240606050948_add_api_code_to_competitions.rb
+++ b/db/migrate/20240606050948_add_api_code_to_competitions.rb
@@ -1,0 +1,5 @@
+class AddApiCodeToCompetitions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :competitions, :api_code, :string
+  end
+end

--- a/db/migrate/20240606055739_add_api_code_to_groups.rb
+++ b/db/migrate/20240606055739_add_api_code_to_groups.rb
@@ -1,0 +1,5 @@
+class AddApiCodeToGroups < ActiveRecord::Migration[6.1]
+  def change
+    add_column :groups, :api_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_05_114427) do
+ActiveRecord::Schema.define(version: 2024_06_06_050948) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "active_storage_attachments", force: :cascade do |t|
@@ -61,6 +60,7 @@ ActiveRecord::Schema.define(version: 2022_12_05_114427) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "current_round_id"
     t.integer "api_id"
+    t.string "api_code"
     t.index ["current_round_id"], name: "index_competitions_on_current_round_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_06_06_050948) do
+ActiveRecord::Schema.define(version: 2024_06_06_055739) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 2024_06_06_050948) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "api_id"
+    t.string "api_code"
     t.index ["round_id"], name: "index_groups_on_round_id"
   end
 

--- a/lib/tasks/competition.rake
+++ b/lib/tasks/competition.rake
@@ -118,22 +118,25 @@ namespace :competition do
   task update_ongoing_matches: :environment do
     competitions = Competition.on_going
     competitions.each do |competition|
-      MatchUpdateFutureJob.perform_later(competition.id)
-      MatchUpdateHistoryJob.perform_later(competition.id)
-      MatchUpdateLiveJob.perform_later(competition.id)
+      # MatchUpdateFutureJob.perform_later(competition.id)
+      # MatchUpdateHistoryJob.perform_later(competition.id)
+      # MatchUpdateLiveJob.perform_later(competition.id)
+      MatchUpdateJob.perform_later(competition.id)
     end
   end
 
   desc "Update upcoming fixtures for a competition"
   task :update_matches_future, [:competition_id] => :environment do |t, args|
     competition = Competition.find(args[:competition_id])
-    MatchUpdateFutureJob.perform_later(competition.id)
+    # MatchUpdateFutureJob.perform_later(competition.id)
+    MatchUpdateJob.perform_later(competition.id)
   end
 
   desc "Update upcoming fixtures for a competition"
   task :update_matches_history, [:competition_id] => :environment do |t, args|
     competition = Competition.find(args[:competition_id])
-    MatchUpdateHistoryJob.perform_later(competition.id)
+    # MatchUpdateHistoryJob.perform_later(competition.id)
+    MatchUpdateJob.perform_later(competition.id)
   end
 
   desc "Copy the first competition and start it today"

--- a/lib/tasks/euros.rake
+++ b/lib/tasks/euros.rake
@@ -90,8 +90,8 @@ namespace :euros do
     # Calling the API to create the matches
     MatchUpdateJob.perform_now(euros.id)
 
-    # TODO: this only works when there are matches
-    puts "...#{euros.rounds.count} Total Teams"
+    # TODO: this only works when there are matches so you'll see 1 for now
+    puts "...#{euros.rounds.count} Total Round"
     puts "...#{euros.teams.count} Total Teams"
     puts "...#{euros.groups.count} Total Groups"
 

--- a/lib/tasks/euros.rake
+++ b/lib/tasks/euros.rake
@@ -58,11 +58,13 @@ namespace :euros do
       },
     }
     puts 'Creating the Euros...'
-    euros = Competition.find_or_create_by(name: 'Euros 2024', start_date: Date.new(2024, 06, 14), end_date: Date.new(2024, 07, 14), api_id: 2018, api_code: 'EC')
+    euros = Competition.find_or_create_by!(name: 'Euros 2024', start_date: Date.new(2024, 06, 14), end_date: Date.new(2024, 07, 14), api_id: 2018, api_code: 'EC')
     puts '.. created the Euros'
 
     puts 'Creating or finding first round...'
-    first_round = Round.find_or_create_by(name: 'Group Stage', number: 1, competition: euros, api_name: 'GROUP_STAGE')
+    first_round = Round.find_or_create_by!(name: 'Group Stage', number: 1, competition: euros, api_name: 'GROUP_STAGE')
+    euros.update!(current_round: first_round)
+    # TODO: this only works when there are matches
     puts "...#{euros.rounds.count} Total Rounds"
 
     puts 'Creating or finding groups...'
@@ -71,10 +73,11 @@ namespace :euros do
       group = Group.find_or_create_by!(name: group_name, round: first_round, api_id: groups[group_name][:api_id])
       groups[group_name][:teams].each do |team_hash|
         puts "Name: #{team_hash[:name]}, Abbrev: #{team_hash[:abbrev]}"
-        team = Team.find_or_create_by(team_hash)
-        Affiliation.find_or_create_by(team: team, group: group)
+        team = Team.find_or_create_by!(team_hash)
+        Affiliation.find_or_create_by!(team: team, group: group)
       end
     end
+    # TODO: this only works when there are matches
     puts "...#{euros.teams.count} Total Teams"
     puts "...#{euros.groups.count} Total Groups"
 
@@ -84,26 +87,26 @@ namespace :euros do
     renato = User.find_by(email: 'renatonato_jr@hotmail.com') || User.create(email: 'renatonato_jr@hotmail.com', password: ENV['ADMIN_PASSWORD'], admin: true)
     caio = User.find_by(email: 'caio.santos@msn.com') || User.create(email: 'caio.santos@msn.com', password: ENV['ADMIN_PASSWORD'], admin: true)
 
-    puts 'Creating a test leaderboards'
-    leaderboard = Leaderboard.find_or_create_by(
+    puts 'Creating test leaderboards'
+    leaderboard = Leaderboard.find_or_create_by!(
       name: 'Admin Leaderboard 1',
       competition: euros,
       user: trouni
     )
-    Membership.find_or_create_by(leaderboard: leaderboard, user: doug)
-    Membership.find_or_create_by(leaderboard: leaderboard, user: james)
-    Membership.find_or_create_by(leaderboard: leaderboard, user: renato)
-    Membership.find_or_create_by(leaderboard: leaderboard, user: caio)
+    Membership.find_or_create_by!(leaderboard: leaderboard, user: doug)
+    Membership.find_or_create_by!(leaderboard: leaderboard, user: james)
+    Membership.find_or_create_by!(leaderboard: leaderboard, user: renato)
+    Membership.find_or_create_by!(leaderboard: leaderboard, user: caio)
 
-    leaderboard = Leaderboard.find_or_create_by(
+    leaderboard = Leaderboard.find_or_create_by!(
       name: 'Admin Leaderboard 2',
       competition: euros,
       user: doug
     )
-    Membership.find_or_create_by(leaderboard: leaderboard, user: trouni)
-    Membership.find_or_create_by(leaderboard: leaderboard, user: james)
-    Membership.find_or_create_by(leaderboard: leaderboard, user: renato)
-    Membership.find_or_create_by(leaderboard: leaderboard, user: caio)
+    Membership.find_or_create_by!(leaderboard: leaderboard, user: trouni)
+    Membership.find_or_create_by!(leaderboard: leaderboard, user: james)
+    Membership.find_or_create_by!(leaderboard: leaderboard, user: renato)
+    Membership.find_or_create_by!(leaderboard: leaderboard, user: caio)
   end
 
 end

--- a/lib/tasks/euros.rake
+++ b/lib/tasks/euros.rake
@@ -1,0 +1,109 @@
+namespace :euros do
+  desc "Create the UEFA Euros competition"
+  task create: :environment do
+    groups = {
+      'Group A' => {
+        api_id: nil,
+        teams: [
+          { name: 'Germany', abbrev: 'GER' },
+          { name: 'Scotland', abbrev: 'SCO' },
+          { name: 'Switzerland', abbrev: 'SUI' },
+          { name: 'Hungary', abbrev: 'HUN' }
+        ]
+      },
+      'Group B' => {
+        api_id: nil,
+        teams: [
+          { name: 'Albania', abbrev: 'ALB' },
+          { name: 'Italy', abbrev: 'ITA' },
+          { name: 'Croatia', abbrev: 'CRO' },
+          { name: 'Spain', abbrev: 'ESP' }
+        ]
+      },
+      'Group C' => {
+        api_id: nil,
+        teams: [
+          { name: 'Denmark', abbrev: 'DEN' },
+          { name: 'England', abbrev: 'ENG' },
+          { name: 'Serbia', abbrev: 'SRB' },
+          { name: 'Slovenia', abbrev: 'SVN' }
+        ]
+      },
+      'Group D' => {
+        api_id: nil,
+        teams: [
+          { name: 'France', abbrev: 'FRA' },
+          { name: 'Netherlands', abbrev: 'NED' },
+          { name: 'Austria', abbrev: 'AUT' },
+          { name: 'Poland', abbrev: 'POL' }
+        ]
+      },
+      'Group E' => {
+        api_id: nil,
+        teams: [
+          { name: 'Belgium', abbrev: 'BEL' },
+          { name: 'Romania', abbrev: 'ROU' },
+          { name: 'Slovakia', abbrev: 'SVK' },
+          { name: 'Ukraine', abbrev: 'UKR' }
+        ]
+      },
+      'Group F' => {
+        api_id: nil,
+        teams: [
+          { name: 'Georgia', abbrev: 'GEO' },
+          { name: 'Portugal', abbrev: 'POR' },
+          { name: 'Czechia', abbrev: 'CZE' },
+          { name: 'Turkey', abbrev: 'TUR' }
+        ]
+      },
+    }
+    puts 'Creating the Euros...'
+    euros = Competition.find_or_create_by(name: 'Euros 2024', start_date: Date.new(2024, 06, 14), end_date: Date.new(2024, 07, 14), api_id: 2018, api_code: 'EC')
+    puts '.. created the Euros'
+
+    puts 'Creating or finding first round...'
+    first_round = Round.find_or_create_by(name: 'Group Stage', number: 1, competition: euros, api_name: 'GROUP_STAGE')
+    puts "...#{euros.rounds.count} Total Rounds"
+
+    puts 'Creating or finding groups...'
+    groups.each_key do |group_name|
+      puts "...#{group_name}..."
+      group = Group.find_or_create_by!(name: group_name, round: first_round, api_id: groups[group_name][:api_id])
+      groups[group_name][:teams].each do |team_hash|
+        puts "Name: #{team_hash[:name]}, Abbrev: #{team_hash[:abbrev]}"
+        team = Team.find_or_create_by(team_hash)
+        Affiliation.find_or_create_by(team: team, group: group)
+      end
+    end
+    puts "...#{euros.teams.count} Total Teams"
+    puts "...#{euros.groups.count} Total Groups"
+
+    doug = User.find_by(email: 'douglasmberkley@gmail.com') || User.create(email: 'douglasmberkley@gmail.com', password: ENV['ADMIN_PASSWORD'], admin: true)
+    trouni = User.find_by(email: 'trouni@gmail.com') || User.create(email: 'trouni@gmail.com', password: ENV['ADMIN_PASSWORD'], admin: true)
+    james = User.find_by(email: 'devereuxjj@gmail.com') || User.create(email: 'devereuxjj@gmail.com', password: ENV['ADMIN_PASSWORD'], admin: true)
+    renato = User.find_by(email: 'renatonato_jr@hotmail.com') || User.create(email: 'renatonato_jr@hotmail.com', password: ENV['ADMIN_PASSWORD'], admin: true)
+    caio = User.find_by(email: 'caio.santos@msn.com') || User.create(email: 'caio.santos@msn.com', password: ENV['ADMIN_PASSWORD'], admin: true)
+
+    puts 'Creating a test leaderboards'
+    leaderboard = Leaderboard.find_or_create_by(
+      name: 'Admin Leaderboard 1',
+      competition: euros,
+      user: trouni
+    )
+    Membership.find_or_create_by(leaderboard: leaderboard, user: doug)
+    Membership.find_or_create_by(leaderboard: leaderboard, user: james)
+    Membership.find_or_create_by(leaderboard: leaderboard, user: renato)
+    Membership.find_or_create_by(leaderboard: leaderboard, user: caio)
+
+    leaderboard = Leaderboard.find_or_create_by(
+      name: 'Admin Leaderboard 2',
+      competition: euros,
+      user: doug
+    )
+    Membership.find_or_create_by(leaderboard: leaderboard, user: trouni)
+    Membership.find_or_create_by(leaderboard: leaderboard, user: james)
+    Membership.find_or_create_by(leaderboard: leaderboard, user: renato)
+    Membership.find_or_create_by(leaderboard: leaderboard, user: caio)
+  end
+
+end

--- a/lib/tasks/euros.rake
+++ b/lib/tasks/euros.rake
@@ -4,6 +4,7 @@ namespace :euros do
     groups = {
       'Group A' => {
         api_id: nil,
+        api_code: 'GROUP_A',
         teams: [
           { name: 'Germany', abbrev: 'GER' },
           { name: 'Scotland', abbrev: 'SCO' },
@@ -13,6 +14,7 @@ namespace :euros do
       },
       'Group B' => {
         api_id: nil,
+        api_code: 'GROUP_B',
         teams: [
           { name: 'Albania', abbrev: 'ALB' },
           { name: 'Italy', abbrev: 'ITA' },
@@ -22,6 +24,7 @@ namespace :euros do
       },
       'Group C' => {
         api_id: nil,
+        api_code: 'GROUP_C',
         teams: [
           { name: 'Denmark', abbrev: 'DEN' },
           { name: 'England', abbrev: 'ENG' },
@@ -31,6 +34,7 @@ namespace :euros do
       },
       'Group D' => {
         api_id: nil,
+        api_code: 'GROUP_D',
         teams: [
           { name: 'France', abbrev: 'FRA' },
           { name: 'Netherlands', abbrev: 'NED' },
@@ -40,6 +44,7 @@ namespace :euros do
       },
       'Group E' => {
         api_id: nil,
+        api_code: 'GROUP_E',
         teams: [
           { name: 'Belgium', abbrev: 'BEL' },
           { name: 'Romania', abbrev: 'ROU' },
@@ -49,6 +54,7 @@ namespace :euros do
       },
       'Group F' => {
         api_id: nil,
+        api_code: 'GROUP_F',
         teams: [
           { name: 'Georgia', abbrev: 'GEO' },
           { name: 'Portugal', abbrev: 'POR' },
@@ -64,13 +70,20 @@ namespace :euros do
     puts 'Creating or finding first round...'
     first_round = Round.find_or_create_by!(name: 'Group Stage', number: 1, competition: euros, api_name: 'GROUP_STAGE')
     euros.update!(current_round: first_round)
+    Round.find_or_create_by!(name: 'Round of 16', number: 2, competition: euros, api_name: 'LAST_16')
+    Round.find_or_create_by!(name: 'Quarter-finals', number: 3, competition: euros, api_name: 'QUARTER_FINALS')
+    Round.find_or_create_by!(name: 'Semi-finals', number: 4, competition: euros, api_name: 'SEMI_FINALS')
+    # TODO: Doesn't look like the API has the 3rd place playoff
+    # Round.find_or_create_by!(name: 'Third Place', number: 5, competition: euros, api_name: '3PPO')
+    Round.find_or_create_by!(name: 'Final', number: 6, competition: euros, api_name: 'FINAL')
+
     # TODO: this only works when there are matches
     puts "...#{euros.rounds.count} Total Rounds"
 
     puts 'Creating or finding groups...'
     groups.each_key do |group_name|
       puts "...#{group_name}..."
-      group = Group.find_or_create_by!(name: group_name, round: first_round, api_id: groups[group_name][:api_id])
+      group = Group.find_or_create_by!(name: group_name, round: first_round, api_id: groups[group_name][:api_id], api_code: groups[group_name][:api_code])
       groups[group_name][:teams].each do |team_hash|
         puts "Name: #{team_hash[:name]}, Abbrev: #{team_hash[:abbrev]}"
         team = Team.find_or_create_by!(team_hash)

--- a/lib/tasks/euros.rake
+++ b/lib/tasks/euros.rake
@@ -120,6 +120,8 @@ namespace :euros do
     Membership.find_or_create_by!(leaderboard: leaderboard, user: james)
     Membership.find_or_create_by!(leaderboard: leaderboard, user: renato)
     Membership.find_or_create_by!(leaderboard: leaderboard, user: caio)
+
+    AttachFlagsJob.perform_now(euros.id)
   end
 
 end

--- a/lib/tasks/euros.rake
+++ b/lib/tasks/euros.rake
@@ -83,7 +83,7 @@ namespace :euros do
       group = Group.find_or_create_by!(name: group_name, round: first_round, api_id: groups[group_name][:api_id], api_code: groups[group_name][:api_code])
       groups[group_name][:teams].each do |team_hash|
         puts "Name: #{team_hash[:name]}, Abbrev: #{team_hash[:abbrev]}"
-        team = Team.find_by!(abbrev: team_hash[:abbrev]) || Team.create!(team_hash)
+        team = Team.find_by(abbrev: team_hash[:abbrev]) || Team.create!(team_hash)
         Affiliation.find_or_create_by!(team: team, group: group)
       end
     end

--- a/lib/tasks/euros.rake
+++ b/lib/tasks/euros.rake
@@ -77,9 +77,6 @@ namespace :euros do
     # Round.find_or_create_by!(name: 'Third Place', number: 5, competition: euros, api_name: '3PPO')
     Round.find_or_create_by!(name: 'Final', number: 6, competition: euros, api_name: 'FINAL')
 
-    # TODO: this only works when there are matches
-    puts "...#{euros.rounds.count} Total Rounds"
-
     puts 'Creating or finding groups...'
     groups.each_key do |group_name|
       puts "...#{group_name}..."
@@ -90,7 +87,11 @@ namespace :euros do
         Affiliation.find_or_create_by!(team: team, group: group)
       end
     end
+    # Calling the API to create the matches
+    MatchUpdateJob.perform_now(euros.id)
+
     # TODO: this only works when there are matches
+    puts "...#{euros.rounds.count} Total Teams"
     puts "...#{euros.teams.count} Total Teams"
     puts "...#{euros.groups.count} Total Groups"
 

--- a/lib/tasks/euros.rake
+++ b/lib/tasks/euros.rake
@@ -83,7 +83,7 @@ namespace :euros do
       group = Group.find_or_create_by!(name: group_name, round: first_round, api_id: groups[group_name][:api_id], api_code: groups[group_name][:api_code])
       groups[group_name][:teams].each do |team_hash|
         puts "Name: #{team_hash[:name]}, Abbrev: #{team_hash[:abbrev]}"
-        team = Team.find_or_create_by!(team_hash)
+        team = Team.find_by!(abbrev: team_hash[:abbrev]) || Team.create!(team_hash)
         Affiliation.find_or_create_by!(team: team, group: group)
       end
     end

--- a/test/jobs/attach_flags_job_test.rb
+++ b/test/jobs/attach_flags_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AttachFlagsJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
The goal was to add both Euros and Copa America but the new [Data-Football API](https://www.football-data.org/) only has the Euros. 

I suggest each person create a free account so that you can get your own API Key
```
FOOTBALL_DATA_TOKEN=******
```

I created a rake task to setup the tournament
```
rails euros:create
```
this will create the teams (with flag upload), groups, rounds, matches, leaderboards, and memberships