### PR TITLE
Update Predictions create and update actions to only allow upcoming matches

### DIFF
--- a/app/controllers/v1/predictions_controller.rb
+++ b/app/controllers/v1/predictions_controller.rb
@@ -1,6 +1,6 @@
 class V1::PredictionsController < ApplicationController
   def create
-    @match = Match.find(params[:match_id])
+    @match = Match.upcoming.find(params[:match_id])
     @prediction = Prediction.new(prediction_params)
     @prediction.match = @match
     @prediction.user = current_user
@@ -13,7 +13,7 @@ class V1::PredictionsController < ApplicationController
   end
 
   def update
-    @prediction = Prediction.find_by(user: current_user, match: params[:match_id])
+    @prediction = Prediction.editable.find_by(user: current_user, match: params[:match_id])
     authorize @prediction
     if @prediction.update(prediction_params)
       render :show

--- a/app/models/prediction.rb
+++ b/app/models/prediction.rb
@@ -6,6 +6,7 @@ class Prediction < ApplicationRecord
   validates :choice, presence: true
   enum choice: { home: 'home', away: 'away', draw: 'draw' }
 
+  scope :editable, -> { joins(:match).where(matches: { status: :upcoming }) }
   scope :locked, -> { joins(:match).where.not(matches: { status: :upcoming }) }
 
   after_commit :refresh_materialized_views


### PR DESCRIPTION
## Scope of this PR

This PR creates a new `editable` scope for predictions and uses it in the `predictions#update` action to prevent editing predictions on matches that are already started or finished.

Didn't look into error handling, just protecting this for now as it should definitely be prevented.

## Notes

We should really add RSpec 😓 