### PR TITLE
removed the filtering for global leaderboard

### DIFF
--- a/app/views/v1/leaderboards/index.json.jbuilder
+++ b/app/views/v1/leaderboards/index.json.jbuilder
@@ -1,7 +1,6 @@
 json.array! @leaderboards do |leaderboard|
   json.partial! leaderboard
   rankings = leaderboard.rankings.order(:user_rank)
-  rankings = rankings.first(leaderboard.rankings_top_n) if leaderboard.rankings_top_n
   json.users rankings do |ranking|
     json.partial! 'v1/leaderboards/ranking', ranking: ranking
   end


### PR DESCRIPTION
removed the filtering for global leaderboard to allow the front-end to have all the info.

But it has repercussions, as you see in the front-end PR