### PR TITLE
Fix/seed deprecation and version issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 gem 'rack-cors', require: 'rack/cors'
 
 # Added
-gem 'cloudinary', '~> 1.16.0'
+gem 'cloudinary'
 gem 'devise'
 gem 'devise_token_auth', github: 'lynndylanhurley/devise_token_auth'
 gem 'faker'

--- a/README.md
+++ b/README.md
@@ -1,12 +1,41 @@
 # predictor-app
 ## Project setup
 
+### Create and populate .env file as follows (do the necessary changes):
+```
+CLOUDINARY_URL=CLOUDINARY_URL=cloudinary://<your_api_key>:<your_api_secret>@yanninthesky
+FOOTBALL_DATA_TOKEN=<your_football_token>
+ADMIN_PASSWORD=lewagonsecret
+```
+
+### Install and run sidekiq
+```
+# On macOS
+brew update
+brew install redis
+brew services start redis
+sidekiq
+```
+
+```
+# On Ubuntu
+curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
+
+echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
+
+sudo apt-get update
+sudo apt-get install redis
+sudo apt-get install redis-server
+sidekiq
+```
+
 ### Create DB / Migrate / Seed
 ```
 rails db:create
 rails db:migrate
 rails db:seed
 ```
+
 ### Installs dependencies
 ```
 bundle install

--- a/app/services/database_views.rb
+++ b/app/services/database_views.rb
@@ -7,7 +7,7 @@ class DatabaseViews
 
   def self.deactivate_callback
     MODELS.each do |model|
-      model.skip_callback(:commit, :after, :refresh_materialized_views)
+      model.skip_callback(:commit, :after, :refresh_materialized_views, raise: false)
     end
   end
 

--- a/app/services/scrape_matches_service.rb
+++ b/app/services/scrape_matches_service.rb
@@ -18,8 +18,9 @@ class ScrapeMatchesService
   end
 
   def call
+    browser_options = %w[--headless --no-sandbox --disable-dev-shm-usage --disable-gpu --remote-debugging-port=9222]
     DatabaseViews.run_without_callback(then_refresh: true) do
-      @browser = Watir::Browser.new :chrome, args: %w[--headless --no-sandbox --disable-dev-shm-usage --disable-gpu --remote-debugging-port=9222]
+      @browser = Watir::Browser.new :chrome, options: {args: browser_options}
       urls.each do |url|
         scrape(url)
       end

--- a/db/seeds/0_default.rb
+++ b/db/seeds/0_default.rb
@@ -13,7 +13,7 @@ puts 'Creating test users...'
 20.times do
   User.create(
     # fake emails for testing purposes
-    email: Faker::Internet.safe_email,
+    email: Faker::Internet.email,
     password: '123123'
   )
 end


### PR DESCRIPTION
## Changes in this PR

This PR contains multiple fix I figured while installing and seeding the app.

### 1. [fix deprecated faker safe_email method](https://github.com/dmbf29/predictor-api/commit/15f57b9e082864d2b53cb2c682ad7790a484199f)

`.safe_email` is [deprecated since last year](https://github.com/faker-ruby/faker/pull/2733), I changed it to `.email`.


### 2. [fix deprecated watir browser option syntax](https://github.com/dmbf29/predictor-api/commit/83c3f016e6194bb9437894215eab1a5448fd2097)

The error I got: `ArgumentError: {:args=>["--headless", "--no-sandbox", "--disable-dev-shm-usage", "--disable-gpu", "--remote-debugging-port=9230"]} are unrecognized arguments for Browser constructor
`
The syntax of WATIR seem to have changed according to [this article](https://stackoverflow.com/questions/73230980/watir-selenium-unrecognized-arguments-for-browser-constructor). 

### 3. [fix deprecated skip_callback syntax](https://github.com/dmbf29/predictor-api/commit/ea9b0125e0a91e135b604e7d454719754605c486) ⚠️ help needed

This is a band-aid not a fix. I got a `refresh_materialized_views not found` error that I shutdown with a `raise: false` following that [gh issue](https://github.com/thoughtbot/factory_bot/issues/931). I did that to move on in the seeding, we might want to keep that error raised actually. Now, the original problem is unknown to me... @trouni you might know better?

### 4. [add project installation details in readme](https://github.com/dmbf29/predictor-api/commit/8b76a2b8cbaa47bce9db2434c7b146e045c56092)

Added some details about running sidekiq and what the .env should look like for future new comers.

### 5. [remove fix cloudinary version to accomodate to new v2 cloudinary lib](https://github.com/dmbf29/predictor-api/commit/d2313dffb404ba39d563b215f9fb28cbfc020b0c)

I removed the fixed cloudinary version as it was not accepting my `.env` CLOUDINARY_URL. I think people starting their projects from today might stumble upon the same problem. I believe this [gh issue](https://github.com/cloudinary/cloudinary_npm/issues/204) talks about that same problem.
