### PR TITLE
switching back to sendgrid

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,12 +55,11 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "predictor_api_production"
 
-  # config.action_mailer.delivery_method = :smtp
-  config.action_mailer.delivery_method = :postmark
-  config.action_mailer.default_url_options = { host: 'http://predict-to-win.herokuapp.com' }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.default_url_options = { host: 'https://www.octacle.app' }
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.raise_delivery_errors = false
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/smtp.rb
+++ b/config/initializers/smtp.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
-# ActionMailer::Base.smtp_settings = {
-#   user_name: ENV['POSTMARK_API'],
-#   password: ENV['POSTMARK_API'],
-#   domain: 'octacle.app',
-#   address: 'smtp.postmarkapp.com',
-#   port: 587,
-#   authentication: :plain,
-#   enable_starttls_auto: true
-# }
-ActionMailer::Base.postmark_settings = { api_token: ENV['POSTMARK_API'] }
+ActionMailer::Base.smtp_settings = {
+  user_name: 'apikey',
+  password: ENV['SENDGRID_API_KEY'],
+  domain: 'octacle.app',
+  address: 'smtp.sendgrid.net',
+  port: 587,
+  authentication: :plain,
+  enable_starttls_auto: true
+}
+
+# ActionMailer::Base.postmark_settings = { api_token: ENV['POSTMARK_API'] }


### PR DESCRIPTION
I created a dummy account for SendGrid. So kicking the can down the road. Our free trial ends on August 2nd, 2026.