### PR TITLE
Now each Sidekiq thread manages its own flag independently — 

### DIFF
--- a/app/jobs/match_update_job.rb
+++ b/app/jobs/match_update_job.rb
@@ -17,6 +17,10 @@ class MatchUpdateJob < ApplicationJob
     ).body
     parsed_response = JSON.parse(response)
     matches = parsed_response['matches']
+    if matches.nil?
+      Rails.logger.error("MatchUpdateJob: unexpected API response — #{parsed_response.inspect}")
+      return
+    end
     DatabaseViews.run_without_callback(then_refresh: true) do
       matches.each do |match_info|
         kickoff_time = DateTime.parse(match_info['utcDate'])

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -12,6 +12,7 @@ class ApplicationRecord < ActiveRecord::Base
   end
 
   def refresh_materialized_views
+    return if Thread.current[:skip_refresh_materialized_views]
     DatabaseViews.refresh(async: true)
   end
 end

--- a/app/services/database_views.rb
+++ b/app/services/database_views.rb
@@ -5,14 +5,24 @@ class DatabaseViews
     async ? RefreshDatabaseViewsJob.perform_later : RefreshDatabaseViewsJob.perform_now
   end
 
+  def self.deactivate_callback
+    Thread.current[:skip_refresh_materialized_views] = true
+  end
+
+  def self.activate_callback(then_refresh: false)
+    Thread.current[:skip_refresh_materialized_views] = false
+    refresh if then_refresh
+  end
+
   def self.run_without_callback(then_refresh: false, &block)
+    previous = Thread.current[:skip_refresh_materialized_views]
     Thread.current[:skip_refresh_materialized_views] = true
     completed = false
     begin
       yield
       completed = true
     ensure
-      Thread.current[:skip_refresh_materialized_views] = false
+      Thread.current[:skip_refresh_materialized_views] = previous
       refresh if completed && then_refresh
     end
   end

--- a/app/services/database_views.rb
+++ b/app/services/database_views.rb
@@ -5,27 +5,15 @@ class DatabaseViews
     async ? RefreshDatabaseViewsJob.perform_later : RefreshDatabaseViewsJob.perform_now
   end
 
-  def self.deactivate_callback
-    MODELS.each do |model|
-      model.skip_callback(:commit, :after, :refresh_materialized_views, raise: false)
-    end
-  end
-
-  def self.activate_callback(then_refresh: false)
-    MODELS.each do |model|
-      model.set_callback(:commit, :after, :refresh_materialized_views)
-    end
-    refresh if then_refresh
-  end
-
   def self.run_without_callback(then_refresh: false, &block)
-    deactivate_callback
+    Thread.current[:skip_refresh_materialized_views] = true
     completed = false
     begin
       yield
       completed = true
     ensure
-      activate_callback(then_refresh: completed && then_refresh)
+      Thread.current[:skip_refresh_materialized_views] = false
+      refresh if completed && then_refresh
     end
   end
 end


### PR DESCRIPTION
no shared mutable state, no races, no duplicate callbacks. The refresh only fires if the block completed successfully, same as before.